### PR TITLE
expose jitter and latency options

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -33,3 +33,5 @@ instances = { min = 2, max = 100, default = 5 }
     [testcases.params]
     numOfChannels =  { type = "int", default = 2 } 
     numOfHubs = {type ="int", default = 1}
+    networkJitterMS = {type="int", default=0}
+    networkLatencyMS = {type="int", default=0}


### PR DESCRIPTION
Fixes #8 

Now that the `testground` fork has been updated to go 1.18 we can use the docker setup locally. This allows us to take advantage of testgrounds ability to add jitter/latency to the network.