### PR TITLE
add virtual defunding to integration test

### DIFF
--- a/create-ledger.go
+++ b/create-ledger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	nitroclient "github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/types"
 	"github.com/testground/sdk-go/network"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
@@ -61,17 +62,19 @@ func createLedgerTest(runEnv *runtime.RunEnv) error {
 }
 
 // createLedgerChannels creates a ledger channel between me and every peer in filtered peers
-func createLedgerChannels(me PeerInfo, runenv *runtime.RunEnv, nc *nitroclient.Client, filteredPeers []PeerInfo) {
+func createLedgerChannels(me PeerInfo, runenv *runtime.RunEnv, nc *nitroclient.Client, filteredPeers []PeerInfo) []types.Destination {
 
 	cm := NewCompletionMonitor(nc, *runenv)
-
+	ledgerIds := []types.Destination{}
 	for _, p := range filteredPeers {
 
-		id := createLedgerChannel(me.Address, p.Address, nc)
-		cm.WatchObjective(id)
+		r := createLedgerChannel(me.Address, p.Address, nc)
+		cm.WatchObjective(r.Id)
+		ledgerIds = append(ledgerIds, r.ChannelId)
 
 	}
 
 	cm.WaitForObjectivesToComplete()
 
+	return ledgerIds
 }

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 	"github.com/testground/sdk-go/run"
 )
 
-
-
 // PeerTransaction is a a transaction that also indicates which peer sent it.
 // This is used to replay a transaction on our local chain instance
 type PeerTransaction struct {
@@ -22,7 +20,7 @@ const PORT_START = 7000
 
 func main() {
 	run.InvokeMap(map[string]interface{}{
-		"create-ledger":  createLedgerTest,
-		"create-virtual": createVirtualTest,
+		"create-ledger":   createLedgerTest,
+		"virtual-payment": createVirtualPaymentTest,
 	})
 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -27,7 +27,7 @@ instances = { min = 2, max = 100, default = 5 }
 
 
 [[testcases]]
-name= "create-virtual"
+name= "virtual-payment"
 instances = { min = 2, max = 100, default = 5 }
 
     [testcases.params]

--- a/utils.go
+++ b/utils.go
@@ -110,7 +110,7 @@ func createNitroClient(me MyInfo, peers map[types.Address]PeerInfo, chain *chain
 
 }
 
-func createLedgerChannel(myAddress types.Address, counterparty types.Address, nitroClient *nitroclient.Client) protocols.ObjectiveId {
+func createLedgerChannel(myAddress types.Address, counterparty types.Address, nitroClient *nitroclient.Client) directfund.ObjectiveResponse {
 	outcome := outcome.Exit{outcome.SingleAssetExit{
 		Allocations: outcome.Allocations{
 			outcome.Allocation{
@@ -134,7 +134,7 @@ func createLedgerChannel(myAddress types.Address, counterparty types.Address, ni
 	}
 	r := nitroClient.CreateDirectChannel(request)
 
-	return r.Id
+	return r
 
 }
 
@@ -157,7 +157,7 @@ func filterPeersByHub(peers map[types.Address]PeerInfo, shouldBeHub bool) []Peer
 	return filteredPeers
 }
 
-func createVirtualChannel(myAddress types.Address, intermediary types.Address, counterparty types.Address, nitroClient *nitroclient.Client) protocols.ObjectiveId {
+func createVirtualChannel(myAddress types.Address, intermediary types.Address, counterparty types.Address, nitroClient *nitroclient.Client) virtualfund.ObjectiveResponse {
 	outcome := outcome.Exit{outcome.SingleAssetExit{
 		Allocations: outcome.Allocations{
 			outcome.Allocation{
@@ -181,7 +181,7 @@ func createVirtualChannel(myAddress types.Address, intermediary types.Address, c
 		Nonce:             rand.Int63(),
 	}
 	r := nitroClient.CreateVirtualChannel(request)
-	return r.Id
+	return r
 
 }
 


### PR DESCRIPTION
Fixes #7 

Adds virtual defunding to the main test.  Due to #11 defunding of the ledger channels is currently commented out.