### PR TITLE
use go 1.18 docker image

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@ builder = "exec:go"
 runner = "local:exec"
 
 [builders."docker:go"]
+build_base_image = "golang:1.18-buster"
 enabled = true
 
 [builders."exec:go"]


### PR DESCRIPTION
This allows us to use docker to build/run tests with our go 1.18 code without upgrading all of testground to go 1.18