### PR TITLE
save logs to output folder

### DIFF
--- a/paymentclient/client.go
+++ b/paymentclient/client.go
@@ -1,11 +1,9 @@
 package paymentclient
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"os"
-	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	m "github.com/statechannels/go-nitro-testground/messaging"
@@ -40,9 +38,8 @@ func NewClient(me peer.MyInfo, peers []peer.PeerInfo, chain *chainservice.MockCh
 
 	ms := m.NewP2PMessageService(me, peers, metrics)
 
-	// TODO: Figure out good place to log this
-	filename := filepath.Join("../artifacts", fmt.Sprintf("testground-%s.log", me.Address))
-	logDestination, _ := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0666)
+	// The outputs folder will be copied when results are collected.
+	logDestination, _ := os.OpenFile("./outputs/nitro-client.log", os.O_CREATE|os.O_WRONLY, 0666)
 
 	client := nitroclient.New(ms, chain, store, logDestination, &engine.PermissivePolicy{}, metrics)
 	cm := newCompletionMonitor(&client)


### PR DESCRIPTION
It looks like the log path accidentally got changed in a refactor into the payment client.

This changes the log destination back to the `output` folder which will be collected by testground. 