### PR TITLE
use InitializedTestCaseFn so sucess is reported

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,6 @@ import (
 
 func main() {
 	run.InvokeMap(map[string]interface{}{
-		"virtual-payment": tests.CreateVirtualPaymentTest,
+		"virtual-payment": run.InitializedTestCaseFn(tests.CreateVirtualPaymentTest),
 	})
 }

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -11,11 +11,12 @@ import (
 	"github.com/statechannels/go-nitro-testground/paymentclient"
 	"github.com/statechannels/go-nitro-testground/peer"
 	"github.com/statechannels/go-nitro-testground/utils"
+	"github.com/testground/sdk-go/run"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
 )
 
-func CreateVirtualPaymentTest(runEnv *runtime.RunEnv) error {
+func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, _ *run.InitContext) error {
 	runEnv.D().SetFrequency(1 * time.Second)
 	ctx := context.Background()
 	// instantiate a sync service client, binding it to the RunEnv.


### PR DESCRIPTION
Fixes #14 

By not using `InitializedTestCaseFn` our test never properly reported success.