### PR TITLE
Update go-nitro to adhere to new public API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/multiformats/go-multiaddr v0.6.0
-	github.com/statechannels/go-nitro v0.0.0-20220718121907-61180ba39b32
+	github.com/statechannels/go-nitro v0.0.0-20220905081307-c5611e8c9e48
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -822,8 +822,8 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/statechannels/go-nitro v0.0.0-20220718121907-61180ba39b32 h1:T5TRmqlFd5lffp7cBj3vwvQ+5tfKIR68Wnmo4HnFBsE=
-github.com/statechannels/go-nitro v0.0.0-20220718121907-61180ba39b32/go.mod h1:qpAcNnCibaCE8mxEDZPeIdGZP5X8dy4xg/soi6fTa/Y=
+github.com/statechannels/go-nitro v0.0.0-20220905081307-c5611e8c9e48 h1:BzBYqRnpr8uWA+7ZtesQn5RWc/StqqRqYBjrI3IeaMg=
+github.com/statechannels/go-nitro v0.0.0-20220905081307-c5611e8c9e48/go.mod h1:FyvRQrNhzYgKLI77TPoZP52jt2oYvZRbtAlA2bUeGZI=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/paymentclient/client.go
+++ b/paymentclient/client.go
@@ -76,15 +76,14 @@ func (c *PaymentClient) CreateLedgerChannels(amount uint) {
 			},
 		}}
 
-		request := directfund.ObjectiveRequest{
+		request := directfund.ObjectiveRequestForConsensusApp{
 			CounterParty:      p.Address,
 			Outcome:           outcome,
-			AppDefinition:     types.Address{},
-			AppData:           types.Bytes{},
 			ChallengeDuration: big.NewInt(0),
 			Nonce:             rand.Int63(),
 		}
-		r := c.client.CreateDirectChannel(request)
+
+		r := c.client.CreateLedgerChannel(request)
 		ids = append(ids, r.Id)
 	}
 	c.cm.waitForObjectivesToComplete(ids)


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro-testground/issues/68

`CreateDirectChannel` was removed from the `go-nitro` public API.