### PR TITLE
Close ledgers channels at end of test

### DIFF
--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -166,6 +166,13 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 		// Run the job(s)
 		utils.RunJobs(createVirtualPaymentsJob, config.PaymentTestDuration, int64(config.ConcurrentPaymentJobs))
+		client.MustSignalAndWait(ctx, "paymentsDone", runEnv.TestInstanceCount)
+
+	} else {
+		client.MustSignalAndWait(ctx, "paymentsDone", runEnv.TestInstanceCount)
+	}
+
+	if me.Role != peer.Hub {
 		// TODO: Closing a ledger channel too soon after closing a virtual channel seems to fail.
 		time.Sleep(time.Duration(250 * time.Millisecond))
 		// Close all the ledger channels with the hub
@@ -177,7 +184,6 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		}
 		cm.WaitForObjectivesToComplete(oIds)
 		runEnv.RecordMessage("All ledger channels closed")
-		// TODO: Check balances on chain
 	}
 
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -166,11 +166,8 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 		// Run the job(s)
 		utils.RunJobs(createVirtualPaymentsJob, config.PaymentTestDuration, int64(config.ConcurrentPaymentJobs))
-		client.MustSignalAndWait(ctx, "paymentsDone", runEnv.TestInstanceCount)
-
-	} else {
-		client.MustSignalAndWait(ctx, "paymentsDone", runEnv.TestInstanceCount)
 	}
+	client.MustSignalAndWait(ctx, "paymentsDone", runEnv.TestInstanceCount)
 
 	if me.Role != peer.Hub {
 		// TODO: Closing a ledger channel too soon after closing a virtual channel seems to fail.

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -127,7 +127,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 					AppDefinition:     types.Address{},
 					AppData:           types.Bytes{},
 					ChallengeDuration: big.NewInt(0),
-					Nonce:             rand.Int63(),
+					Nonce:             int64(rand.Int31()),
 				}
 
 				r := nClient.CreateVirtualChannel(request)

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -16,10 +16,17 @@ import (
 	nitro "github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 	"github.com/testground/sdk-go/network"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
+)
+
+const (
+	FINNEY_IN_WEI = 1000000000000000
+	GWEI_IN_WEI   = 1000000000
+	KWEI_IN_WEI   = 1000
 )
 
 // ConfigureNetworkClient configures a network client with the given jitter and latency settings.
@@ -158,4 +165,30 @@ func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uin
 
 	cm.WaitForObjectivesToComplete(ids)
 	return cIds
+}
+
+// GenerateVirtualFundObjectiveRequest generates a virtual channel request  with 10 gwei in funding
+func GenerateVirtualFundObjectiveRequest(me, payee, hub types.Address) virtualfund.ObjectiveRequest {
+	outcome := outcome.Exit{outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: types.AddressToDestination(me),
+				Amount:      big.NewInt(int64(10 * GWEI_IN_WEI)),
+			},
+			outcome.Allocation{
+				Destination: types.AddressToDestination(payee),
+				Amount:      big.NewInt(0),
+			},
+		},
+	}}
+
+	return virtualfund.ObjectiveRequest{
+		CounterParty:      payee,
+		Intermediary:      hub,
+		Outcome:           outcome,
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             int64(rand.Int31()),
+	}
 }

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -124,9 +124,9 @@ func SelectRandom[U ~[]T, T any](collection U) T {
 // CreateLedgerChannels creates a directly funded ledger channel with each hub in hubs.
 // The funding for each channel will be set to amount for both participants.
 // This function blocks until all ledger channels have successfully been created.
-func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uint, me peer.PeerInfo, peers []peer.PeerInfo) {
+func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uint, me peer.PeerInfo, peers []peer.PeerInfo) []types.Destination {
 	ids := []protocols.ObjectiveId{}
-
+	cIds := []types.Destination{}
 	for _, p := range peers {
 		if p.Role != peer.Hub {
 			continue
@@ -152,9 +152,10 @@ func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uin
 			Nonce:             rand.Int63(),
 		}
 		r := client.CreateLedgerChannel(request)
+		cIds = append(cIds, r.ChannelId)
 		ids = append(ids, r.Id)
 	}
 
 	cm.WaitForObjectivesToComplete(ids)
-
+	return cIds
 }

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -149,7 +149,7 @@ func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uin
 			Outcome:      outcome,
 
 			ChallengeDuration: big.NewInt(0),
-			Nonce:             rand.Int63(),
+			Nonce:             int64(rand.Int31()),
 		}
 		r := client.CreateLedgerChannel(request)
 		cIds = append(cIds, r.ChannelId)


### PR DESCRIPTION
Based on #79 Fixes #75 

This calls `CloseLedger` before the end of the test
