### PR TITLE
Record sender/receiver on message metrics

### DIFF
--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -53,270 +53,6 @@
         "type": "influxdb",
         "uid": "9j-fr9MVk"
       },
-      "description": "Grouped by 10 second intervals to smooth the chart",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "$tag_sender",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "9j-fr9MVk"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "sender"
-              ],
-              "type": "tag"
-            }
-          ],
-          "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.msg_size.gauge",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        }
-      ],
-      "title": "Average Message Size By Sender",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "9j-fr9MVk"
-      },
-      "description": "Grouped by 10 second intervals to smooth the chart",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "$tag_receiver",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "9j-fr9MVk"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "receiver"
-              ],
-              "type": "tag"
-            }
-          ],
-          "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.msg_size.gauge",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter GROUP BY time(10s), \"receiver\"",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        }
-      ],
-      "title": "Average Message Size By Receiver",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "9j-fr9MVk"
-      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -375,7 +111,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 9
       },
       "id": 2,
       "options": {
@@ -508,7 +244,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 9
       },
       "id": 11,
       "options": {
@@ -631,7 +367,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 18
       },
       "id": 4,
       "options": {
@@ -656,12 +392,6 @@
           "groupBy": [
             {
               "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
                 "receiver"
               ],
               "type": "tag"
@@ -680,10 +410,6 @@
                   "value"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
               }
             ]
           ],
@@ -696,7 +422,7 @@
           ]
         }
       ],
-      "title": "Average Proposal Count by Receiver",
+      "title": "Proposal Count by Receiver",
       "type": "timeseries"
     },
     {
@@ -762,7 +488,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 18
       },
       "id": 12,
       "options": {
@@ -787,12 +513,6 @@
           "groupBy": [
             {
               "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
                 "sender"
               ],
               "type": "tag"
@@ -811,10 +531,6 @@
                   "value"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
               }
             ]
           ],
@@ -827,7 +543,119 @@
           ]
         }
       ],
-      "title": "Average Proposal Count by Sender",
+      "title": "Proposal Count by Sender",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "9j-fr9MVk"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 23,
+        "x": 0,
+        "y": 27
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Receiver $tag_wallet",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "9j-fr9MVk"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "wallet"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "diagnostics.go-nitro-virtual-payment.messages_queue.gauge",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Incoming Message Queue",
       "type": "timeseries"
     }
   ],
@@ -840,8 +668,8 @@
       {
         "current": {
           "selected": false,
-          "text": "cci97k8nr2ghl88sh1b0",
-          "value": "cci97k8nr2ghl88sh1b0"
+          "text": "ccic020nr2ghccis987g",
+          "value": "ccic020nr2ghccis987g"
         },
         "datasource": {
           "type": "influxdb",
@@ -863,8 +691,8 @@
       {
         "current": {
           "selected": false,
-          "text": "10",
-          "value": "10"
+          "text": "100",
+          "value": "100"
         },
         "datasource": {
           "type": "influxdb",
@@ -886,8 +714,8 @@
       {
         "current": {
           "selected": false,
-          "text": "2m0s",
-          "value": "2m0s"
+          "text": "10s",
+          "value": "10s"
         },
         "datasource": {
           "type": "influxdb",
@@ -1001,8 +829,8 @@
       {
         "current": {
           "selected": false,
-          "text": "10",
-          "value": "10"
+          "text": "4",
+          "value": "4"
         },
         "datasource": {
           "type": "influxdb",
@@ -1047,13 +875,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
-    "to": "now"
+    "from": "2022-09-16T18:27:13.394Z",
+    "to": "2022-09-16T18:27:49.028Z"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Message Stats",
   "uid": "miulKz7Vk",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -128,7 +128,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_sender",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -142,7 +142,7 @@
             },
             {
               "params": [
-                "wallet"
+                "sender"
               ],
               "type": "tag"
             }
@@ -176,7 +176,7 @@
           ]
         }
       ],
-      "title": "Average Message Size",
+      "title": "Average Message Size By Sender",
       "type": "timeseries"
     },
     {
@@ -184,7 +184,7 @@
         "type": "influxdb",
         "uid": "9j-fr9MVk"
       },
-      "description": "Grouped by 10 second intervals",
+      "description": "Grouped by 10 second intervals to smooth the chart",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -225,8 +225,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -244,7 +243,7 @@
         "x": 12,
         "y": 9
       },
-      "id": 7,
+      "id": 10,
       "options": {
         "legend": {
           "calcs": [],
@@ -259,7 +258,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_receiver",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -267,22 +266,22 @@
           "groupBy": [
             {
               "params": [
-                "10s"
+                "1s"
               ],
               "type": "time"
             },
             {
               "params": [
-                "wallet"
+                "receiver"
               ],
               "type": "tag"
             }
           ],
           "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.msg_payload_size.gauge",
+          "measurement": "diagnostics.go-nitro-virtual-payment.msg_size.gauge",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT meanvalue FROM \"diagnostics.go-nitro-virtual-payment.msg_payload_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter AND value != 0 GROUP BY \"wallet\"",
+          "query": "SELECT mean(\"value\") FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter GROUP BY time(10s), \"receiver\"",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -309,7 +308,7 @@
           ]
         }
       ],
-      "title": "Average Payload Size",
+      "title": "Average Message Size By Receiver",
       "type": "timeseries"
     },
     {
@@ -392,7 +391,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_sender",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -400,7 +399,13 @@
           "groupBy": [
             {
               "params": [
-                "wallet"
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "sender"
               ],
               "type": "tag"
             }
@@ -409,6 +414,8 @@
           "measurement": "diagnostics.go-nitro-virtual-payment.msg_size.gauge",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT \"value\" FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter GROUP BY \"sebder\"",
+          "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -418,6 +425,10 @@
                   "value"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
               }
             ]
           ],
@@ -430,7 +441,7 @@
           ]
         }
       ],
-      "title": "Message Size",
+      "title": "Message Size by Sender",
       "type": "timeseries"
     },
     {
@@ -498,7 +509,7 @@
         "x": 12,
         "y": 18
       },
-      "id": 5,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [],
@@ -513,7 +524,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_receiver",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -521,23 +532,17 @@
           "groupBy": [
             {
               "params": [
-                "$interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "wallet"
+                "receiver"
               ],
               "type": "tag"
             }
           ],
           "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.msg_payload_count.gauge",
+          "measurement": "diagnostics.go-nitro-virtual-payment.msg_size.gauge",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value FROM \"diagnostics.go-nitro-virtual-payment.msg_payload_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter AND value != 0 GROUP BY \"wallet\"",
-          "rawQuery": true,
+          "query": "SELECT \"value\" FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter GROUP BY \"receiver\"",
+          "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -547,10 +552,6 @@
                   "value"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
               }
             ]
           ],
@@ -563,7 +564,7 @@
           ]
         }
       ],
-      "title": "Payload Size",
+      "title": "Message Size by Receiver",
       "type": "timeseries"
     },
     {
@@ -620,7 +621,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -630,7 +632,7 @@
         "x": 0,
         "y": 27
       },
-      "id": 3,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -645,7 +647,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_receiver",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -653,13 +655,19 @@
           "groupBy": [
             {
               "params": [
-                "wallet"
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "receiver"
               ],
               "type": "tag"
             }
           ],
           "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.msg_payment_count.gauge",
+          "measurement": "diagnostics.go-nitro-virtual-payment.msg_proposal_count.gauge",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "B",
@@ -671,6 +679,10 @@
                   "value"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
               }
             ]
           ],
@@ -683,7 +695,7 @@
           ]
         }
       ],
-      "title": "Payment Count",
+      "title": "Average Proposal Count by Receiver",
       "type": "timeseries"
     },
     {
@@ -691,7 +703,7 @@
         "type": "influxdb",
         "uid": "9j-fr9MVk"
       },
-      "description": "The amount of proposals in a message",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -740,7 +752,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -750,7 +763,7 @@
         "x": 12,
         "y": 27
       },
-      "id": 4,
+      "id": 12,
       "options": {
         "legend": {
           "calcs": [],
@@ -765,7 +778,7 @@
       },
       "targets": [
         {
-          "alias": "$tag_wallet",
+          "alias": "$tag_sender",
           "datasource": {
             "type": "influxdb",
             "uid": "9j-fr9MVk"
@@ -773,7 +786,13 @@
           "groupBy": [
             {
               "params": [
-                "wallet"
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "sender"
               ],
               "type": "tag"
             }
@@ -791,6 +810,10 @@
                   "value"
                 ],
                 "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
               }
             ]
           ],
@@ -803,7 +826,7 @@
           ]
         }
       ],
-      "title": "Proposal count",
+      "title": "Average Proposal Count by Sender",
       "type": "timeseries"
     }
   ],
@@ -816,8 +839,8 @@
       {
         "current": {
           "selected": false,
-          "text": "cch2unonr2guvn8sce20",
-          "value": "cch2unonr2guvn8sce20"
+          "text": "cci90vgnr2ghl88sh190",
+          "value": "cci90vgnr2ghl88sh190"
         },
         "datasource": {
           "type": "influxdb",
@@ -839,8 +862,8 @@
       {
         "current": {
           "selected": false,
-          "text": "5",
-          "value": "5"
+          "text": "10",
+          "value": "10"
         },
         "datasource": {
           "type": "influxdb",
@@ -862,8 +885,8 @@
       {
         "current": {
           "selected": false,
-          "text": "3m0s",
-          "value": "3m0s"
+          "text": "30s",
+          "value": "30s"
         },
         "datasource": {
           "type": "influxdb",
@@ -885,8 +908,8 @@
       {
         "current": {
           "selected": false,
-          "text": "4",
-          "value": "4"
+          "text": "1",
+          "value": "1"
         },
         "datasource": {
           "type": "influxdb",
@@ -908,8 +931,8 @@
       {
         "current": {
           "selected": false,
-          "text": "7",
-          "value": "7"
+          "text": "1",
+          "value": "1"
         },
         "datasource": {
           "type": "influxdb",
@@ -977,8 +1000,8 @@
       {
         "current": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "10",
+          "value": "10"
         },
         "datasource": {
           "type": "influxdb",
@@ -1023,13 +1046,13 @@
     ]
   },
   "time": {
-    "from": "2022-09-14T19:45:14.491Z",
-    "to": "2022-09-14T19:48:51.695Z"
+    "from": "now-5m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Message Stats",
   "uid": "miulKz7Vk",
-  "version": 5,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -65,9 +65,9 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -136,12 +136,6 @@
           "groupBy": [
             {
               "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
                 "sender"
               ],
               "type": "tag"
@@ -162,10 +156,6 @@
                   "value"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
               }
             ]
           ],
@@ -198,7 +188,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -206,7 +196,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "stepBefore",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -321,9 +311,9 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -442,9 +432,9 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
-            "gradientMode": "none",
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -668,8 +658,8 @@
       {
         "current": {
           "selected": false,
-          "text": "ccic020nr2ghccis987g",
-          "value": "ccic020nr2ghccis987g"
+          "text": "ccicpa0nr2ghccis98a0",
+          "value": "ccicpa0nr2ghccis98a0"
         },
         "datasource": {
           "type": "influxdb",
@@ -691,8 +681,8 @@
       {
         "current": {
           "selected": false,
-          "text": "100",
-          "value": "100"
+          "text": "50",
+          "value": "50"
         },
         "datasource": {
           "type": "influxdb",
@@ -829,8 +819,8 @@
       {
         "current": {
           "selected": false,
-          "text": "4",
-          "value": "4"
+          "text": "10",
+          "value": "10"
         },
         "datasource": {
           "type": "influxdb",
@@ -875,8 +865,8 @@
     ]
   },
   "time": {
-    "from": "2022-09-16T18:27:13.394Z",
-    "to": "2022-09-16T18:27:49.028Z"
+    "from": "2022-09-16T19:21:22.370Z",
+    "to": "2022-09-16T19:24:02.997Z"
   },
   "timepicker": {},
   "timezone": "",

--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -225,7 +225,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -622,7 +623,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -753,7 +754,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -839,8 +840,8 @@
       {
         "current": {
           "selected": false,
-          "text": "cci90vgnr2ghl88sh190",
-          "value": "cci90vgnr2ghl88sh190"
+          "text": "cci97k8nr2ghl88sh1b0",
+          "value": "cci97k8nr2ghl88sh1b0"
         },
         "datasource": {
           "type": "influxdb",
@@ -885,8 +886,8 @@
       {
         "current": {
           "selected": false,
-          "text": "30s",
-          "value": "30s"
+          "text": "2m0s",
+          "value": "2m0s"
         },
         "datasource": {
           "type": "influxdb",
@@ -1053,6 +1054,6 @@
   "timezone": "",
   "title": "Message Stats",
   "uid": "miulKz7Vk",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -136,7 +136,7 @@
           "groupBy": [
             {
               "params": [
-                "10s"
+                "1s"
               ],
               "type": "time"
             },
@@ -1054,6 +1054,6 @@
   "timezone": "",
   "title": "Message Stats",
   "uid": "miulKz7Vk",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/messaging/service.go
+++ b/messaging/service.go
@@ -194,7 +194,7 @@ func (h *P2PMessageService) recordOutgoingMessageMetrics(msg protocols.Message, 
 	for _, p := range msg.ObjectivePayloads {
 		totalPayloadsSize += len(p.PayloadData)
 	}
-	h.metrics.Gauge(fmt.Sprintf("msg__payload_size,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(totalPayloadsSize))
+	h.metrics.Gauge(fmt.Sprintf("msg_payload_size,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(totalPayloadsSize))
 
 	h.metrics.Gauge(fmt.Sprintf("msg_size,wallet,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(len(raw)))
 }

--- a/messaging/service.go
+++ b/messaging/service.go
@@ -87,17 +87,6 @@ func NewP2PMessageService(me peer.MyInfo, peers []peer.PeerInfo, metrics *runtim
 				}
 				h.checkError(err)
 				m, err := protocols.DeserializeMessage(raw)
-				
-				h.metrics.Gauge(fmt.Sprintf("msg_proposal_count,wallet=%s", me.Address)).Update(float64(len(m.LedgerProposals)))
-				h.metrics.Gauge(fmt.Sprintf("msg_payment_count,wallet=%s", me.Address)).Update(float64(len(m.Payments)))
-				h.metrics.Gauge(fmt.Sprintf("msg_payload_count,wallet=%s", me.Address)).Update(float64(len(m.ObjectivePayloads)))
-
-				totalPayloadsSize := 0
-				for _, p := range m.ObjectivePayloads {
-					totalPayloadsSize += len(p.PayloadData)
-				}
-				h.metrics.Gauge(fmt.Sprintf("msg_payload_size,wallet=%s", me.Address)).Update(float64(totalPayloadsSize))
-				h.metrics.Gauge(fmt.Sprintf("msg_size,wallet=%s", me.Address)).Update(float64(len(raw)))
 
 				h.checkError(err)
 				h.out <- m
@@ -149,6 +138,7 @@ func (s *P2PMessageService) connectToPeers() {
 		case m := <-s.in:
 			raw, err := m.Serialize()
 			s.checkError(err)
+			s.recordOutgoingMessageMetrics(m, []byte(raw))
 			writer := bufio.NewWriter(peerStreams[m.To])
 			_, err = writer.WriteString(raw)
 			s.checkError(err)
@@ -162,9 +152,10 @@ func (s *P2PMessageService) connectToPeers() {
 }
 
 // Send dispatches messages
-func (s *P2PMessageService) Send(msg protocols.Message) {
+func (h *P2PMessageService) Send(msg protocols.Message) {
+
 	// TODO: Now that the in chan has been deprecated from the API we should remove in from this message serviceß
-	s.in <- msg
+	h.in <- msg
 }
 
 // checkError panics if the SimpleTCPMessageService is running, otherwise it just returns
@@ -191,4 +182,19 @@ func (s *P2PMessageService) Close() {
 	close(s.quit)
 	s.p2pHost.Close()
 
+}
+
+// recordOutgoingMessageMetrics records various metrics about an outgoing message using the metrics API
+func (h *P2PMessageService) recordOutgoingMessageMetrics(msg protocols.Message, raw []byte) {
+	h.metrics.Gauge(fmt.Sprintf("msg_proposal_count,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(len(msg.LedgerProposals)))
+	h.metrics.Gauge(fmt.Sprintf("msg__payment_count,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(len(msg.Payments)))
+	h.metrics.Gauge(fmt.Sprintf("msg_payload_count,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(len(msg.ObjectivePayloads)))
+
+	totalPayloadsSize := 0
+	for _, p := range msg.ObjectivePayloads {
+		totalPayloadsSize += len(p.PayloadData)
+	}
+	h.metrics.Gauge(fmt.Sprintf("msg__payload_size,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(totalPayloadsSize))
+
+	h.metrics.Gauge(fmt.Sprintf("msg_size,wallet,sender=%s,receiver=%s", h.me.Address, msg.To)).Update(float64(len(raw)))
 }


### PR DESCRIPTION
Record who the `sender` and the `receiver` are on a message when recording metrics.

This lets us put together dashboards by sender/receiver
![image](https://user-images.githubusercontent.com/1620336/190717334-e4905bfd-74ff-4d41-bdad-165005a391ab.png)
