### PR TITLE
Update go-nitro to 1cb1038

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/multiformats/go-multiaddr v0.6.0
-	github.com/statechannels/go-nitro v0.0.0-20220915164938-332f2eabdca2
+	github.com/statechannels/go-nitro v0.0.0-20220919164519-1cb103873211
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -827,8 +827,8 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/statechannels/go-nitro v0.0.0-20220915164938-332f2eabdca2 h1:9XBAMfU4nOGj1DB3Pusv5R1OgLOE80WCT6WZJyL1NGU=
-github.com/statechannels/go-nitro v0.0.0-20220915164938-332f2eabdca2/go.mod h1:QFdUCZT0Du/1kCBTUUhcgvGxyvgHcGs71AVdpZseNfA=
+github.com/statechannels/go-nitro v0.0.0-20220919164519-1cb103873211 h1:UXP65URaXctXzxLZBHhBatd/V4tsJDe6IkW86YNBjCI=
+github.com/statechannels/go-nitro v0.0.0-20220919164519-1cb103873211/go.mod h1:QFdUCZT0Du/1kCBTUUhcgvGxyvgHcGs71AVdpZseNfA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -155,7 +155,7 @@ func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uin
 			CounterParty: p.Address,
 			Outcome:      outcome,
 
-			ChallengeDuration: big.NewInt(0),
+			ChallengeDuration: 0,
 			Nonce:             rand.Uint64(),
 		}
 		r := client.CreateLedgerChannel(request)
@@ -188,7 +188,7 @@ func GenerateVirtualFundObjectiveRequest(me, payee, hub types.Address) virtualfu
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 }


### PR DESCRIPTION
Fix API calls broken due to challenge duration type change in `go-nitro`