### PR TITLE
update readme so we no longer use ip address for influx-db

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,15 +68,10 @@ Testground will automatically run a docker container for influxDb to record metr
 
 At the moment there is some manual configuration to connect grafana to the metrics database:
 
-1. Find the IP of the influxDB container by running the following command:
 
-   ```shell
-   docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' testground-influxdb
-   ```
+1. Go to the [local grafana instance](http://localhost:3000/datasources/new) and add a new **InfluxDb** datasource with the following properties:
 
-2. Go to the [local grafana instance](http://localhost:3000/datasources/new) and add a new **InfluxDb** datasource with the following properties:
-
-   - **Url**: http://192.18.0.6:8086 (where 192.18.0.6 is the IP from step 1)
+   - **Url**: http://testground-influxdb:8086 
    - **Database**: testground
 
-3. Import dashboards into [grafana](http://localhost:3000/dashboard/import) from the [dashboards directory](./dashboards/).
+2. Import dashboards into [grafana](http://localhost:3000/dashboard/import) from the [dashboards directory](./dashboards/).


### PR DESCRIPTION
Fixes #96 

Updates the readme to use the container name `influx-db` when setting up the grafana datasource.

This removes a step to get the ip address of influx-db and also avoids any issues when the `influx-db` instance gets a new ip after restarting.