### PR TITLE
Wait for virtual defund objective to complete

### DIFF
--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -132,7 +132,8 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 			// TODO: get payment balance and output it to the log
 			runEnv.RecordMessage("Closing %s with payment to %s", utils.Abbreviate(channelId), utils.Abbreviate(randomPayee.Address))
-			nClient.CloseVirtualChannel(channelId)
+			closeId := nClient.CloseVirtualChannel(channelId)
+			cm.WaitForObjectivesToComplete([]protocols.ObjectiveId{closeId})
 
 		}
 


### PR DESCRIPTION
Fixes #83

This PR updates our test so we wait for the virtual defund objective to complete before moving on.

Previously we wouldn't wait for the virtual defund objective to complete. This meant that we could attempt to close a ledger channel while we still had running virtual defund objectives. [Closing a ledger channel too early silent fails](https://github.com/statechannels/go-nitro/issues/883) which causes the whole test to stall out.

With this PR I can  run
```
testground --endpoint=http://34.168.92.245:8042  run s -p=go-nitro-testground -t=virtual-payment -b=docker:go -r=local:docker -tp=numOfHubs=1 -tp=numOfPayers=10 -tp=numOfPayees=1  -i=12  -tp=paymentTestDuration=20  -tp=concurrentPaymentJobs=5
``` 

and have it [pass](https://github.com/statechannels/go-nitro-testground/issues/83) where previously it would fail closing ledger channels.