### PR TITLE
Record and display go-nitro version in metrics

### DIFF
--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.1.4"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,24 +61,24 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 24,
         "x": 0,
         "y": 0
       },
       "id": 9,
       "options": {
-        "content": "<table style=\"width:100%\"> \n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
+        "content": "<table style=\"width:100%\"> \n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n    <tr>\n    <td>Nitro version</td>\n    <td>${nitroVersion}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
         "mode": "html"
       },
       "pluginVersion": "9.1.4",
@@ -51,7 +88,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "description": "",
       "fieldConfig": {
@@ -111,7 +148,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 2,
       "options": {
@@ -131,7 +168,7 @@
           "alias": "$tag_sender",
           "datasource": {
             "type": "influxdb",
-            "uid": "9j-fr9MVk"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -174,7 +211,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "description": "",
       "fieldConfig": {
@@ -234,7 +271,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 10
       },
       "id": 11,
       "options": {
@@ -254,7 +291,7 @@
           "alias": "$tag_receiver",
           "datasource": {
             "type": "influxdb",
-            "uid": "9j-fr9MVk"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -297,7 +334,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "description": "",
       "fieldConfig": {
@@ -357,7 +394,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "id": 4,
       "options": {
@@ -377,7 +414,7 @@
           "alias": "$tag_receiver",
           "datasource": {
             "type": "influxdb",
-            "uid": "9j-fr9MVk"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -418,7 +455,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "description": "",
       "fieldConfig": {
@@ -478,7 +515,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 19
       },
       "id": 12,
       "options": {
@@ -498,7 +535,7 @@
           "alias": "$tag_sender",
           "datasource": {
             "type": "influxdb",
-            "uid": "9j-fr9MVk"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -539,7 +576,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "9j-fr9MVk"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -597,7 +634,7 @@
         "h": 8,
         "w": 23,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 14,
       "options": {
@@ -617,7 +654,7 @@
           "alias": "Receiver $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "9j-fr9MVk"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -656,22 +693,18 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "ccicpa0nr2ghccis98a0",
-          "value": "ccicpa0nr2ghccis98a0"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "select  run,count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where $timeFilter",
+        "definition": "select  run,value FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" where $timeFilter",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "runId",
         "options": [],
-        "query": "select  run,count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where $timeFilter",
+        "query": "select  run,value FROM \"diagnostics.go-nitro-virtual-payment.msg_size.gauge\" where $timeFilter",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -679,22 +712,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "50",
-          "value": "50"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT concurrentJobs, mean FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run = '$runId'",
+        "definition": "SELECT concurrentJobs, value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run = '$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "jobCount",
         "options": [],
-        "query": "SELECT concurrentJobs, mean FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run = '$runId'",
+        "query": "SELECT concurrentJobs, value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run = '$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -702,22 +731,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "10s",
-          "value": "10s"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"duration\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"duration\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "testDuration",
         "options": [],
-        "query": "SELECT \"duration\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"duration\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -725,22 +750,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "1",
-          "value": "1"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"hubs\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"hubs\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "hubs",
         "options": [],
-        "query": "SELECT \"hubs\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"hubs\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -748,22 +769,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "1",
-          "value": "1"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payees\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payees\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payees",
         "options": [],
-        "query": "SELECT \"payees\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payees\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -771,22 +788,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "0",
-          "value": "0"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"jitter\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"jitter\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "jitter",
         "options": [],
-        "query": "SELECT \"jitter\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"jitter\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -794,22 +807,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "0",
-          "value": "0"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"latency\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"latency\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "latency",
         "options": [],
-        "query": "SELECT \"latency\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"latency\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -817,22 +826,18 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "10",
-          "value": "10"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payers",
         "options": [],
-        "query": "SELECT \"payers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -840,22 +845,37 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "0",
-          "value": "0"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "9j-fr9MVk"
+          "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payeePayers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payeePayers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payeepayers",
         "options": [],
-        "query": "SELECT \"payeePayers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payeePayers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SELECT \"nitroVersion\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "nitroVersion",
+        "options": [],
+        "query": "SELECT \"nitroVersion\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -865,13 +885,13 @@
     ]
   },
   "time": {
-    "from": "2022-09-16T19:21:22.370Z",
-    "to": "2022-09-16T19:24:02.997Z"
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Message Stats",
   "uid": "miulKz7Vk",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboards/time-to-first-payment.json
+++ b/dashboards/time-to-first-payment.json
@@ -9,13 +9,13 @@
       "pluginName": "InfluxDB"
     }
   ],
-  "__elements": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.5.6"
+      "version": "9.1.4"
     },
     {
       "type": "datasource",
@@ -62,7 +62,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1656961312525,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -72,243 +71,19 @@
         "uid": "${DS_INFLUXDB}"
       },
       "gridPos": {
-        "h": 9,
-        "w": 5,
+        "h": 10,
+        "w": 11,
         "x": 0,
         "y": 0
       },
       "id": 4,
       "options": {
-        "content": "<table>\n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
+        "content": "<table style=\"width:100%\">\n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n    <tr>\n    <td>Nitro Version</td>\n    <td>${nitroVersion}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
         "mode": "html"
       },
-      "pluginVersion": "8.5.6",
+      "pluginVersion": "9.1.4",
       "title": "Run details",
       "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 5,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Handle API",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "linear"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "diagnostics.go-nitro-virtual-payment.handle_api_event.timer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "Handle API",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        },
-        {
-          "alias": "Handle Message",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "linear"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.handle_message.timer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "Handle Message",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        },
-        {
-          "alias": "Crank",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "linear"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "diagnostics.go-nitro-virtual-payment.crank.timer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "Crank",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        }
-      ],
-      "title": "Average Function Durations",
-      "type": "timeseries"
     },
     {
       "datasource": {
@@ -322,6 +97,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 100000000,
@@ -370,7 +147,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 12,
         "x": 11,
         "y": 0
@@ -382,7 +159,8 @@
             "mean"
           ],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -453,6 +231,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -502,7 +282,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 12,
       "options": {
@@ -511,7 +291,8 @@
             "mean"
           ],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -603,6 +384,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -652,7 +435,7 @@
         "h": 9,
         "w": 12,
         "x": 11,
-        "y": 9
+        "y": 10
       },
       "id": 5,
       "options": {
@@ -661,7 +444,8 @@
             "mean"
           ],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -728,7 +512,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -758,13 +542,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT concurrentJobs, mean FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run = '$runId'",
+        "definition": "SELECT concurrentJobs, value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run = '$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "jobCount",
         "options": [],
-        "query": "SELECT concurrentJobs, mean FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run = '$runId'",
+        "query": "SELECT concurrentJobs, value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run = '$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -777,13 +561,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"duration\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"duration\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "testDuration",
         "options": [],
-        "query": "SELECT \"duration\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"duration\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -796,13 +580,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"hubs\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"hubs\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "hubs",
         "options": [],
-        "query": "SELECT \"hubs\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"hubs\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -815,13 +599,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payees\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payees\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payees",
         "options": [],
-        "query": "SELECT \"payees\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payees\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -834,13 +618,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"jitter\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"jitter\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "jitter",
         "options": [],
-        "query": "SELECT \"jitter\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"jitter\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -853,13 +637,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"latency\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"latency\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "latency",
         "options": [],
-        "query": "SELECT \"latency\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"latency\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -873,13 +657,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"me\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": " \"SELECT \\\"me\\\",count FROM \\\"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\\\" where run='$runId'\"",
         "hide": 2,
-        "includeAll": true,
-        "multi": false,
+        "includeAll": false,
+        "multi": true,
         "name": "clientAdds",
         "options": [],
-        "query": "SELECT \"me\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": " \"SELECT \\\"me\\\",count FROM \\\"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\\\" where run='$runId'\"",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -892,13 +676,13 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payers",
         "options": [],
-        "query": "SELECT \"payers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -911,13 +695,32 @@
           "type": "influxdb",
           "uid": "${DS_INFLUXDB}"
         },
-        "definition": "SELECT \"payeePayers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "definition": "SELECT \"payeePayers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "payeepayers",
         "options": [],
-        "query": "SELECT \"payeePayers\",count FROM \"diagnostics.go-nitro-virtual-payment.time_to_first_payment.timer\" where run='$runId'",
+        "query": "SELECT \"payeePayers\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "SELECT \"nitroVersion\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "nitroVersion",
+        "options": [],
+        "query": "SELECT \"nitroVersion\",value FROM \"diagnostics.go-nitro-virtual-payment.run_info.point\" where run='$runId'",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -927,13 +730,13 @@
     ]
   },
   "time": {
-    "from": "2022-07-04T18:55:21.082Z",
-    "to": "2022-07-04T19:02:08.311Z"
+    "from": "now-30m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Time to First Payment",
   "uid": "5OBBeW37k",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -47,8 +47,9 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		panic(err)
 	}
 	me := peer.GenerateMe(seq, config, ip.String())
-
 	runEnv.RecordMessage("I am %+v", me)
+
+	utils.RecordRunInfo(me, config, runEnv.D())
 
 	// We wait until everyone has chosen an address.
 	client.MustSignalAndWait(ctx, "peerInfoGenerated", runEnv.TestInstanceCount)
@@ -94,11 +95,8 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 			randomHub := utils.SelectRandom(hubs)
 			randomPayee := utils.SelectRandom(payees)
 
-			runDetails := fmt.Sprintf("me=%s,role=%v,hubs=%d,payers=%d,payees=%d,payeePayers=%d,duration=%s,concurrentJobs=%d,jitter=%d,latency=%d",
-				me.Address, me.Role, config.NumHubs, config.NumPayers, config.NumPayees, config.NumPayeePayers, config.PaymentTestDuration, config.ConcurrentPaymentJobs, config.NetworkJitter.Milliseconds(), config.NetworkLatency.Milliseconds())
-
 			var channelId types.Destination
-			runEnv.D().Timer("time_to_first_payment," + runDetails).Time(func() {
+			runEnv.D().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Time(func() {
 
 				request := utils.GenerateVirtualFundObjectiveRequest(me.Address, randomPayee.Address, randomHub.Address)
 				r := nClient.CreateVirtualChannel(request)

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -198,16 +198,24 @@ func GenerateVirtualFundObjectiveRequest(me, payee, hub types.Address) virtualfu
 // RecordRunInfo records a single point using the metrics API tagged with the various parameters and versions for the run.
 func RecordRunInfo(me peer.MyInfo, config config.RunConfig, metrics *runtime.MetricsApi) {
 	info, _ := debug.ReadBuildInfo()
-
-	var version string
+	testVersion := info.Main.Version
+	var nitroVersion string
+	var tgVersion string
+	var tgSdkVersion string
 	for _, dep := range info.Deps {
-		if dep.Path == "github.com/statechannels/go-nitro" {
-			version = dep.Version
+		switch dep.Path {
+		case "github.com/statechannels/go-nitro":
+			nitroVersion = dep.Version
+		case "github.com/testground/testground":
+			tgVersion = dep.Version
+		case "github.com/testground/sdk-go":
+			tgSdkVersion = dep.Version
 		}
 	}
 
-	runDetails := fmt.Sprintf("nitroVersion=%s,me=%s,role=%v,hubs=%d,payers=%d,payees=%d,payeePayers=%d,duration=%s,concurrentJobs=%d,jitter=%d,latency=%d",
-		version, me.Address, me.Role, config.NumHubs, config.NumPayers,
+	runDetails := fmt.Sprintf("nitroVersion=%s,testVersion=%s,tgVersion=%s,tgSdkVersion=%s,me=%s,role=%v,hubs=%d,payers=%d,payees=%d,payeePayers=%d,duration=%s,concurrentJobs=%d,jitter=%d,latency=%d",
+		nitroVersion, testVersion, tgVersion, tgSdkVersion,
+		me.Address, me.Role, config.NumHubs, config.NumPayers,
 		config.NumPayees, config.NumPayeePayers,
 		config.PaymentTestDuration, config.ConcurrentPaymentJobs,
 		config.NetworkJitter.Milliseconds(), config.NetworkLatency.Milliseconds())


### PR DESCRIPTION
Fixes #85 

Two changes:
- We now record run related info using the `run_info` metrics. This lets us record the info once instead of including it everytime we record a `time_to_first_payment_metric`.
- Since `go 1.18` you can get version info using [ReadBuildInfo](https://pkg.go.dev/runtime/debug#ReadBuildInfo). We use this to get the `go-nitro` version.

We are also recording the version of testground, the testground sdk, and the go-nitro-testground version. This information is currently not used in the dashboards but we might as well record it now in case we want to report on it later.
```
nitroVersion=v0.0.0-20220919164519-1cb103873211,testVersion=(devel),tgVersion=v0.5.3,tgSdkVersion=v0.3.0
```

![image](https://user-images.githubusercontent.com/1620336/191615001-7c3beb79-6856-4da8-bb69-a26907b5e5bb.png)
