### PR TITLE
Enable Dashboards link on Testground tasks page

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -1,4 +1,4 @@
-name = "go-nitro"
+name = "go-nitro-testground"
 [defaults]
 builder = "exec:go"
 runner = "local:exec"

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -26,7 +26,7 @@ import (
 )
 
 func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) error {
-	runEnv.D().SetFrequency(1 * time.Second)
+
 	ctx := context.Background()
 
 	client := init.SyncClient
@@ -59,12 +59,12 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 	store := store.NewMemStore(crypto.FromECDSA(&me.PrivateKey))
 
-	ms := m.NewP2PMessageService(me, peers, runEnv.D())
+	ms := m.NewP2PMessageService(me, peers, runEnv.R())
 
 	// The outputs folder will be copied when results are collected.
 	logDestination, _ := os.OpenFile("./outputs/nitro-client.log", os.O_CREATE|os.O_WRONLY, 0666)
 
-	nClient := nitro.New(ms, chain.NewChainService(seq, logDestination), store, logDestination, &engine.PermissivePolicy{}, runEnv.D())
+	nClient := nitro.New(ms, chain.NewChainService(seq, logDestination), store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
 
 	cm := utils.NewCompletionMonitor(&nClient, runEnv.RecordMessage)
 	defer cm.Close()
@@ -96,7 +96,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 			randomPayee := utils.SelectRandom(payees)
 
 			var channelId types.Destination
-			runEnv.D().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Time(func() {
+			runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Time(func() {
 
 				request := utils.GenerateVirtualFundObjectiveRequest(me.Address, randomPayee.Address, randomHub.Address)
 				r := nClient.CreateVirtualChannel(request)


### PR DESCRIPTION
Fixes #94 

By a little bit of spelunking through the testground code I've figured out why the dashboard link isn't working for us:
- We are using the `diagnositics` metrics API not [results](https://docs.testground.ai/writing-test-plans/observability-assets-and-metrics#results). Testground uses a hardcoded query that assumes metrics are `results`.
- Our test plan name differs from our repo name.  It looks like the folder we import from (ie:`testground plan import --from ./go-nitro-testground`) gets used when recording metrics. However the dashboard link uses name from our config file. This means we had a mismatch between `go-nitro-testground` and `go-nitro`

This PR 
- Switches all metric calls to use `RunEnv.R()` the results metric API.  Note that by switching to the `results` metric API metrics are only available once the test run **completes**
- Updates the name in our config file so it matches the repository name.

The dashboard link now works ([example](http://34.168.92.245:8042/dashboard?task_id=cclq0vonr2ggslmv7tqg)) but it turns out not to be super useful. It returns a bunch of auto generated graphs for every metrics it can find. However the graphs seem kind of wonky?


For example I can see values in the labels on hover but I don't see anything on the chart.
![image](https://user-images.githubusercontent.com/1620336/191630714-c47612db-886c-49bc-90ee-b805c274d6e4.png)
