### PR TITLE
Record Mean TTFP per run for CI/Nightly runs

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -28,6 +28,8 @@ name = "virtual-payment"
 
 [testcases.params]
 concurrentPaymentJobs = {type = "int", desc = "The number of concurrent payment jobs a peer should attempt to maintain", default = 1}
+isCI = {type = "bool", default = false, desc = "Whether this test is being run as from CI"}
+isNightly = {type = "bool", default = false, desc = "Whether this test is being run as part of the nightly test suite"}
 networkJitter = {type = "int", unit = "milliseconds", default = 0}
 networkLatency = {type = "int", unit = "milliseconds", default = 0}
 numOfHubs = {type = "int", default = 1, desc = "The number of instances that should play the role of the hub"}

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -169,6 +169,16 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		runEnv.RecordMessage("All ledger channels closed")
 	}
 
+	// Record the mean time to first payment to nightly/ci metrics if applicable
+	// This allows us to track performance over time
+	mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
+	if runEnv.BooleanParam("isNightly") {
+		runEnv.R().RecordPoint(fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
+	}
+	if runEnv.BooleanParam("isCI") {
+		runEnv.R().RecordPoint(fmt.Sprintf("ci_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
+	}
+
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)
 
 	return nil


### PR DESCRIPTION
Towards https://github.com/statechannels/go-nitro-testground/issues/107

This PR adds two new parameters to the testground test `iSCI` and `isNightly` (they default to false). These flags are used to indicate that a testground run is part of either a nightly run or a CI run.

If a run is part of a CI or nightly run we record the mean TTFP for the run. This will allow us to track the changes to TTFP over time for CI and nightly.

Dashboards will be created in a [separate PR ](https://github.com/statechannels/go-nitro-testground/issues/new)once we have a bit more data.