### PR TITLE
Do not rely on a hardcoded NitroAdjudicator address

### DIFF
--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -2,26 +2,24 @@ package chain
 
 import (
 	"context"
+	"encoding/hex"
 	"io"
 	"log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
+	Create2Deployer "github.com/statechannels/go-nitro/client/engine/chainservice/create2deployer"
+	"github.com/testground/sdk-go/runtime"
+	"github.com/testground/sdk-go/sync"
 )
 
-func NewChainService(seq int64, logDestination io.Writer) chainservice.ChainService {
+func NewChainService(ctx context.Context, syncClient sync.Client, runEnv *runtime.RunEnv, seq int64, logDestination io.Writer) chainservice.ChainService {
 	client, err := ethclient.Dial("ws://hardhat:8545/")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// TODO: do not hardcode the NitroAdjudicator address. Instead, find address on chain
-	naAddress := common.HexToAddress("0x5fbdb2315678afecb367f032d93f642f64180aa3")
-	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -30,13 +28,54 @@ func NewChainService(seq int64, logDestination io.Writer) chainservice.ChainServ
 	if err != nil {
 		log.Fatal(err)
 	}
-	txSubmitter.GasLimit = uint64(300000) // in units
+	txSubmitter.GasLimit = uint64(30_000_000) // in units
 
 	gasPrice, err := client.SuggestGasPrice(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
 	txSubmitter.GasPrice = gasPrice
+
+	deployer, err := Create2Deployer.NewCreate2Deployer(common.HexToAddress("0x5fbdb2315678afecb367f032d93f642f64180aa3"), client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	hexBytecode, err := hex.DecodeString(NitroAdjudicator.NitroAdjudicatorMetaData.Bin[2:])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	naAddress, err := deployer.ComputeAddress(&bind.CallOpts{}, [32]byte{}, crypto.Keccak256Hash(hexBytecode))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// One testground instance attempts to deploy NitroAdjudicator
+	if seq == 1 {
+		bytecode, err := client.CodeAt(ctx, naAddress, nil) // nil is latest block
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Has NitroAdjudicator been deployed? If not, deploy it.
+		if len(bytecode) == 0 {
+			_, err = deployer.Deploy(txSubmitter, big.NewInt(0), [32]byte{}, hexBytecode)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+
+	// All instances wait for until the NitroAdjudicator has been deployed.
+	contractSetup := sync.State("contractSetup")
+	syncClient.MustSignalEntry(ctx, contractSetup)
+	syncClient.MustBarrier(ctx, contractSetup, runEnv.TestInstanceCount)
+
+	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	cs, err := chainservice.NewEthChainService(client, na, naAddress, common.Address{}, common.Address{}, txSubmitter, logDestination)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/multiformats/go-multiaddr v0.6.0
-	github.com/statechannels/go-nitro v0.0.0-20220922174011-3e33cafaa1f3
+	github.com/statechannels/go-nitro v0.0.0-20221004165356-5d2a8306f2b4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -827,8 +827,8 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/statechannels/go-nitro v0.0.0-20220922174011-3e33cafaa1f3 h1:YJtZyilH56jp592m3am56ASaJ46Uge/YhaGghD/It0k=
-github.com/statechannels/go-nitro v0.0.0-20220922174011-3e33cafaa1f3/go.mod h1:QFdUCZT0Du/1kCBTUUhcgvGxyvgHcGs71AVdpZseNfA=
+github.com/statechannels/go-nitro v0.0.0-20221004165356-5d2a8306f2b4 h1:+fKrz+oFnh4vgD2lCYH7Ev/zf6+2HeiUzyJu66MDD8w=
+github.com/statechannels/go-nitro v0.0.0-20221004165356-5d2a8306f2b4/go.mod h1:QFdUCZT0Du/1kCBTUUhcgvGxyvgHcGs71AVdpZseNfA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -68,7 +68,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	// The outputs folder will be copied when results are collected.
 	logDestination, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0666)
 
-	nClient := nitro.New(ms, chain.NewChainService(seq, logDestination), store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
+	nClient := nitro.New(ms, chain.NewChainService(ctx, client, runEnv, seq, logDestination), store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
 
 	cm := utils.NewCompletionMonitor(&nClient, runEnv.RecordMessage)
 	defer cm.Close()


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro-testground/issues/95.

On every testground run:
1. Testground instance with sequence number 1 checks if NitroAdjudicator has been deployed. If not, the instance deploys the adjudicator.
2. All instances block until the adjudicator is deployed.

Create2 is used for deploys, so a new deploy is only triggered when the creation code for NitroAdjudicator changes. Since NitroAdjudicator has no constructor, the creation code is the same as the bytecode.

Note that the following are important:
- Create2Deployer must exist at the hardcoded address.
- The same nonce should be used for all deploys.

The benefit of the above approach is that the testsuite will automatically use a deployed NitroAdjudicator contract version from the go-nitro package. Before this work, NitroAdjudicator version deployed on the chain could differ from the version supplied by the go-nitro package.