### PR TITLE
Move contract deployment synchronization code out of chain service and into test script

### DIFF
--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -14,11 +14,9 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	Create2Deployer "github.com/statechannels/go-nitro/client/engine/chainservice/create2deployer"
-	"github.com/testground/sdk-go/runtime"
-	"github.com/testground/sdk-go/sync"
 )
 
-func NewChainService(ctx context.Context, syncClient sync.Client, runEnv *runtime.RunEnv, seq int64, logDestination io.Writer) chainservice.ChainService {
+func NewChainService(ctx context.Context, seq int64, logDestination io.Writer) chainservice.ChainService {
 	client, err := ethclient.Dial("ws://hardhat:8545/")
 	if err != nil {
 		log.Fatal(err)
@@ -66,11 +64,6 @@ func NewChainService(ctx context.Context, syncClient sync.Client, runEnv *runtim
 			}
 		}
 	}
-
-	// All instances wait for until the NitroAdjudicator has been deployed.
-	contractSetup := sync.State("contractSetup")
-	syncClient.MustSignalEntry(ctx, contractSetup)
-	syncClient.MustBarrier(ctx, contractSetup, runEnv.TestInstanceCount)
 
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -88,7 +88,13 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	// The outputs folder will be copied when results are collected.
 	logDestination, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0666)
 
-	nClient := nitro.New(ms, chain.NewChainService(ctx, client, runEnv, seq, logDestination), store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
+	// All instances wait until the NitroAdjudicator has been deployed (seq = 1 instance is responsible)
+	cs := chain.NewChainService(ctx, seq, logDestination)
+	contractSetup := sync.State("contractSetup")
+	client.MustSignalEntry(ctx, contractSetup)
+	client.MustBarrier(ctx, contractSetup, runEnv.TestInstanceCount)
+
+	nClient := nitro.New(ms, cs, store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
 
 	cm := utils.NewCompletionMonitor(&nClient, runEnv.RecordMessage)
 	defer cm.Close()


### PR DESCRIPTION
Follows on from #95 

This is a minor refactor, aimed at improved readability and separation of concerns. 

The chain service in this repo is a sort of wrapper for the actual go-nitro "production" chain service. In fact it is really just a different constructor for the same type. To me it seems unfortunate for the "synchronization code" we put it into our test scritps to leak into the chain service, even if it is only into this wrapper-constructor. 


TODO: 
- [x] test this PR locally