### PR TITLE
Add ci/nightly dashboard

### DIFF
--- a/dashboards/ci-and-nightly-TTFP.json
+++ b/dashboards/ci-and-nightly-TTFP.json
@@ -68,12 +68,11 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisGridShow": true,
             "axisLabel": "",
             "axisPlacement": "auto",
             "fillOpacity": 80,
@@ -89,6 +88,8 @@
             }
           },
           "mappings": [],
+          "min": 0,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -97,8 +98,12 @@
                 "value": null
               },
               {
+                "color": "yellow",
+                "value": 75000000
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 100000000
               }
             ]
           },
@@ -112,25 +117,26 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 6,
       "options": {
         "barRadius": 0,
-        "barWidth": 0.97,
+        "barWidth": 0.62,
+        "colorByField": "mean",
         "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "orientation": "horizontal",
-        "showValue": "never",
+        "showValue": "auto",
         "stacking": "none",
         "tooltip": {
           "mode": "multi",
-          "sort": "asc"
+          "sort": "none"
         },
-        "xField": "run",
+        "xField": "runCompletedAt",
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
@@ -147,13 +153,25 @@
                 "run"
               ],
               "type": "tag"
+            },
+            {
+              "params": [
+                "nitroVersion"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "runCompletedAt"
+              ],
+              "type": "tag"
             }
           ],
-          "measurement": "results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point",
+          "measurement": "results.go-nitro-testground-virtual-payment.nightly_mean_time_to_first_payment.point",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT    min(\"value\"),mean(\"value\"), max(\"value\") FROM \"results.go-nitro-testground-virtual-payment.nightly_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
-          "rawQuery": true,
+          "query": "SELECT    mean(\"value\") FROM \"results.go-nitro-testground-virtual-payment.nightly_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
           "select": [
@@ -168,20 +186,12 @@
                 "params": [],
                 "type": "mean"
               }
-            ],
-            [
-              {
-                "params": [
-                  "time"
-                ],
-                "type": "field"
-              }
             ]
           ],
           "tags": []
         }
       ],
-      "title": "Nightly TTFP",
+      "title": "Nightly Mean TTFP",
       "type": "barchart"
     },
     {
@@ -189,16 +199,15 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisGridShow": true,
-            "axisLabel": "",
             "axisPlacement": "auto",
             "fillOpacity": 80,
             "gradientMode": "none",
@@ -213,6 +222,8 @@
             }
           },
           "mappings": [],
+          "min": 0,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -221,8 +232,12 @@
                 "value": null
               },
               {
+                "color": "yellow",
+                "value": 75000000
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 100000000
               }
             ]
           },
@@ -236,25 +251,26 @@
         "x": 12,
         "y": 0
       },
-      "id": 3,
+      "id": 5,
       "options": {
         "barRadius": 0,
-        "barWidth": 0.97,
+        "barWidth": 0.62,
+        "colorByField": "mean",
         "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "orientation": "horizontal",
-        "showValue": "never",
+        "showValue": "auto",
         "stacking": "none",
         "tooltip": {
           "mode": "multi",
-          "sort": "asc"
+          "sort": "none"
         },
-        "xField": "run",
+        "xField": "runCompletedAt",
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
@@ -271,13 +287,25 @@
                 "run"
               ],
               "type": "tag"
+            },
+            {
+              "params": [
+                "nitroVersion"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "runCompletedAt"
+              ],
+              "type": "tag"
             }
           ],
           "measurement": "results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT    min(\"value\"),mean(\"value\"), max(\"value\") FROM \"results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
-          "rawQuery": true,
+          "query": "SELECT    mean(\"value\") FROM \"results.go-nitro-testground-virtual-payment.nightly_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
           "select": [
@@ -292,20 +320,12 @@
                 "params": [],
                 "type": "mean"
               }
-            ],
-            [
-              {
-                "params": [
-                  "time"
-                ],
-                "type": "field"
-              }
             ]
           ],
           "tags": []
         }
       ],
-      "title": "CI TTFP",
+      "title": "CI Mean TTFP",
       "type": "barchart"
     }
   ],
@@ -317,13 +337,13 @@
     "list": []
   },
   "time": {
-    "from": "now-5y",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "CI and Nightly TTFP",
   "uid": "HcF7hb4Vz",
-  "version": 6,
+  "version": 8,
   "weekStart": ""
 }

--- a/dashboards/ci-and-nightly-TTFP.json
+++ b/dashboards/ci-and-nightly-TTFP.json
@@ -1,0 +1,329 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.1.6"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        },
+        "xField": "run",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "run"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT    min(\"value\"),mean(\"value\"), max(\"value\") FROM \"results.go-nitro-testground-virtual-payment.nightly_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "time"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Nightly TTFP",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        },
+        "xField": "run",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "run"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT    min(\"value\"),mean(\"value\"), max(\"value\") FROM \"results.go-nitro-testground-virtual-payment.ci_mean_time_to_first_payment.point\" WHERE $timeFilter and value!=0 GROUP BY \"run\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "time"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "CI TTFP",
+      "type": "barchart"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CI and Nightly TTFP",
+  "uid": "HcF7hb4Vz",
+  "version": 6,
+  "weekStart": ""
+}

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -200,19 +200,19 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
 	if runEnv.BooleanParam("isNightly") {
 		runEnv.R().RecordPoint(
-			fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,date=%s",
+			fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
 				me.Address,
 				utils.GetVersion("github.com/statechannels/go-nitro"),
-				time.Now().Format("2006-01-02"),
+				time.Now().Format("2006-01-02 15:04:05"),
 			), float64(mean))
 	}
 
 	if runEnv.BooleanParam("isCI") {
 		runEnv.R().RecordPoint(
-			fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,date=%s",
+			fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
 				me.Address,
 				utils.GetVersion("github.com/statechannels/go-nitro"),
-				time.Now().Format("2006-01-02"),
+				time.Now().Format("2006-01-02 15:04:05"),
 			), float64(mean))
 	}
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -197,15 +197,23 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 	// Record the mean time to first payment to nightly/ci metrics if applicable
 	// This allows us to track performance over time
-	// We restrict this to the payer to avoid inserting time_to_first_payment metrics for every client
-	if me.IsPayer() {
-		mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
-		if runEnv.BooleanParam("isNightly") {
-			runEnv.R().RecordPoint(fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
-		}
-		if runEnv.BooleanParam("isCI") {
-			runEnv.R().RecordPoint(fmt.Sprintf("ci_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
-		}
+	mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
+	if runEnv.BooleanParam("isNightly") {
+		runEnv.R().RecordPoint(
+			fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,date=%s",
+				me.Address,
+				utils.GetVersion("github.com/statechannels/go-nitro"),
+				time.Now().Format("2006-01-02"),
+			), float64(mean))
+	}
+
+	if runEnv.BooleanParam("isCI") {
+		runEnv.R().RecordPoint(
+			fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,date=%s",
+				me.Address,
+				utils.GetVersion("github.com/statechannels/go-nitro"),
+				time.Now().Format("2006-01-02"),
+			), float64(mean))
 	}
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)
 

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -195,26 +195,29 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		runEnv.RecordMessage("All ledger channels closed")
 	}
 
-	// Record the mean time to first payment to nightly/ci metrics if applicable
-	// This allows us to track performance over time
-	mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
-	if runEnv.BooleanParam("isNightly") {
-		runEnv.R().RecordPoint(
-			fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
-				me.Address,
-				utils.GetVersion("github.com/statechannels/go-nitro"),
-				time.Now().Format("2006-01-02 15:04:05"),
-			), float64(mean))
+	if me.IsPayer() {
+		// Record the mean time to first payment to nightly/ci metrics if applicable
+		// This allows us to track performance over time
+		mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
+		if runEnv.BooleanParam("isNightly") {
+			runEnv.R().RecordPoint(
+				fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
+					me.Address,
+					utils.GetVersion("github.com/statechannels/go-nitro"),
+					time.Now().Format("2006-01-02 15:04:05"),
+				), float64(mean))
+		}
+
+		if runEnv.BooleanParam("isCI") {
+			runEnv.R().RecordPoint(
+				fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
+					me.Address,
+					utils.GetVersion("github.com/statechannels/go-nitro"),
+					time.Now().Format("2006-01-02 15:04:05"),
+				), float64(mean))
+		}
 	}
 
-	if runEnv.BooleanParam("isCI") {
-		runEnv.R().RecordPoint(
-			fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
-				me.Address,
-				utils.GetVersion("github.com/statechannels/go-nitro"),
-				time.Now().Format("2006-01-02 15:04:05"),
-			), float64(mean))
-	}
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)
 
 	return nil

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -204,7 +204,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 				fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
 					me.Address,
 					utils.GetVersion("github.com/statechannels/go-nitro"),
-					time.Now().Format("2006-01-02 15:04:05"),
+					time.Now().Format("2006-01-02 15:04"),
 				), float64(mean))
 		}
 
@@ -213,7 +213,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 				fmt.Sprintf("ci_mean_time_to_first_payment,me=%s,nitroVersion=%s,runCompletedAt=%s",
 					me.Address,
 					utils.GetVersion("github.com/statechannels/go-nitro"),
-					time.Now().Format("2006-01-02 15:04:05"),
+					time.Now().Format("2006-01-02 15:04"),
 				), float64(mean))
 		}
 	}

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -208,26 +208,28 @@ func CreateLedgerChannels(client nitro.Client, cm *CompletionMonitor, amount uin
 	return cIds
 }
 
+func GetVersion(path string) string {
+	info, _ := debug.ReadBuildInfo()
+	for _, dep := range info.Deps {
+		switch dep.Path {
+		case path:
+			return dep.Version
+
+		}
+	}
+	panic("could not find version for " + path)
+}
+
 // RecordRunInfo records a single point using the metrics API tagged with the various parameters and versions for the run.
 func RecordRunInfo(me peer.MyInfo, config config.RunConfig, metrics *runtime.MetricsApi) {
 	info, _ := debug.ReadBuildInfo()
 	testVersion := info.Main.Version
-	var nitroVersion string
-	var tgVersion string
-	var tgSdkVersion string
-	for _, dep := range info.Deps {
-		switch dep.Path {
-		case "github.com/statechannels/go-nitro":
-			nitroVersion = dep.Version
-		case "github.com/testground/testground":
-			tgVersion = dep.Version
-		case "github.com/testground/sdk-go":
-			tgSdkVersion = dep.Version
-		}
-	}
+	nitroVersion := GetVersion("github.com/statechannels/go-nitro")
+	tgVersion := GetVersion("github.com/testground/testground")
+	tgSDKVersion := GetVersion("github.com/testground/sdk-go")
 
 	runDetails := fmt.Sprintf("nitroVersion=%s,testVersion=%s,tgVersion=%s,tgSdkVersion=%s,me=%s,role=%v,hubs=%d,payers=%d,payees=%d,payeePayers=%d,duration=%s,concurrentJobs=%d,jitter=%d,latency=%d",
-		nitroVersion, testVersion, tgVersion, tgSdkVersion,
+		nitroVersion, testVersion, tgVersion, tgSDKVersion,
 		me.Address, me.Role, config.NumHubs, config.NumPayers,
 		config.NumPayees, config.NumPayeePayers,
 		config.PaymentTestDuration, config.ConcurrentPaymentJobs,


### PR DESCRIPTION
Fixes #110 

Adds a dashboard that monitors the new CI/nightly benchmarks. It can be viewed [here](http://34.168.92.245:3000/d/HcF7hb4Vz/ci-and-nightly-ttfp?orgId=1&from=1667943464371&to=1667944364371)

![image](https://user-images.githubusercontent.com/1620336/200683323-6bacd6e8-b70e-4e50-a57b-e91a2736e0b3.png)