### PR TITLE
Allow outbound HTTPS communication

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -6,6 +6,9 @@ runner = "local:exec"
 [builders."docker:go"]
 build_base_image = "golang:1.19-buster"
 enabled = true
+[builders."docker:go".dockerfile_extensions]
+post_runtime_copy = "COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt"
+pre_source_copy = "RUN update-ca-certificates --verbose"
 
 [builders."exec:go"]
 enabled = true

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -43,8 +43,9 @@ func ConfigureNetworkClient(ctx context.Context, netClient *network.Client, sync
 
 		config := network.Config{
 			// Control the "default" network. At the moment, this is the only network.
-			Network: "default",
-			Enable:  true,
+			Network:       "default",
+			Enable:        true,
+			RoutingPolicy: network.AllowAll,
 
 			// Set the traffic shaping characteristics.
 			Default: network.LinkShape{


### PR DESCRIPTION
This is work to support running the fevm chain using the testground test. It allows outbound docker traffic so the chain service can communicate with the https node. It enables outbound communication, and makes sure the certificate store gets copied the docker instances, so the HTTPs cert can be validated.