### PR TITLE
Sleep before the payment test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,7 @@ func GetRunConfig(runEnv *runtime.RunEnv) (RunConfig, error) {
 func (c *RunConfig) GetSleepDuration() time.Duration {
 
 	// The duration we wait is based on the payment test duration and the amount of concurrent jobs.
-	toSleep := c.PaymentTestDuration / 10 * time.Duration(c.ConcurrentPaymentJobs)
+	toSleep := (c.PaymentTestDuration / 10) * time.Duration(c.ConcurrentPaymentJobs)
 	// Restrict the sleep duration to be between 1 and 30 seconds
 	if toSleep > 30*time.Second {
 		toSleep = 30 * time.Second

--- a/config/config.go
+++ b/config/config.go
@@ -47,3 +47,18 @@ func GetRunConfig(runEnv *runtime.RunEnv) (RunConfig, error) {
 
 	return config, err
 }
+
+// GetSleepDuration calculates the duration to sleep before and after the payment test.
+func (c *RunConfig) GetSleepDuration() time.Duration {
+
+	// The duration we wait is based on the payment test duration and the amount of concurrent jobs.
+	toSleep := c.PaymentTestDuration / 10 * time.Duration(c.ConcurrentPaymentJobs)
+	// Restrict the sleep duration to be between 1 and 30 seconds
+	if toSleep > 30*time.Second {
+		toSleep = 30 * time.Second
+	}
+	if toSleep < 1*time.Second {
+		toSleep = 1 * time.Second
+	}
+	return toSleep
+}

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -108,6 +108,9 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	ledgerIds := utils.CreateLedgerChannels(nClient, cm, utils.FINNEY_IN_WEI, me.PeerInfo, peers)
 
 	client.MustSignalAndWait(ctx, sync.State("ledgerDone"), runEnv.TestInstanceCount)
+	toSleep := runConfig.GetSleepDuration()
+	runEnv.RecordMessage("Waiting %s before starting payments", toSleep)
+	time.Sleep(toSleep)
 
 	if me.IsPayer() {
 
@@ -174,16 +177,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		// Run the job(s)
 		utils.RunJobs(createVirtualPaymentsJob, runConfig.PaymentTestDuration, int64(runConfig.ConcurrentPaymentJobs))
 
-		// We wait to allow hubs to finish processing messages and close out their channels.
-		// The duration we wait is based on the payment test duration and the amount of concurrent jobs.
-		toSleep := runConfig.PaymentTestDuration / 10 * time.Duration(runConfig.ConcurrentPaymentJobs)
-		// Restrict the sleep duration to be between 1 and 30 seconds
-		if toSleep > 30*time.Second {
-			toSleep = 30 * time.Second
-		}
-		if toSleep < 1*time.Second {
-			toSleep = 1 * time.Second
-		}
+		toSleep := runConfig.GetSleepDuration()
 		runEnv.RecordMessage("Waiting %s before closing ledger channels", toSleep)
 		time.Sleep(toSleep)
 	}


### PR DESCRIPTION
Our TTFP [graph](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=cd8p6jonr2gof2poc0t0&var-jobCount=1&var-testDuration=30s&var-hubs=1&var-payees=1&var-jitter=2&var-latency=15&var-payers=10&var-payeepayers=0&var-nitroVersion=v0.0.0-20221006155253-f0e74994b9e4&from=1666290439947&to=1666290777620) shows that at the start TTFP takes a long time and then speeds up.
![image](https://user-images.githubusercontent.com/1620336/197038802-fb792efb-0f3c-4767-b455-4f5eb1654a19.png)

This is because we don't wait after creating the ledger channels, so hubs may still be processing the ledger channels when payments start coming in.

To avoid this I've added a wait (similiar to the one we do before closing the ledger channels) before starting payments. This avoids the spike in TTFP at the start on the [graph](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=cd8pro0nr2gvtehs3qs0&var-jobCount=2&var-testDuration=1m0s&var-hubs=1&var-payees=5&var-jitter=10&var-latency=0&var-payers=2&var-payeepayers=0&var-nitroVersion=v0.0.0-20221009024643-ab7b1a648d10&from=1666293235145&to=1666293412565).
![image](https://user-images.githubusercontent.com/1620336/197039157-24cbf631-001a-4b3d-87ec-e4ea62bbdc47.png)


Since we expect ledger channels to be long living, I think it's pretty reasonable for the test to wait a bit before attempting to use them.