### PR TITLE
Restrict ci/nightly metrics to Payer

### DIFF
--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -205,14 +205,16 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 
 	// Record the mean time to first payment to nightly/ci metrics if applicable
 	// This allows us to track performance over time
-	mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
-	if runEnv.BooleanParam("isNightly") {
-		runEnv.R().RecordPoint(fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
+	// We restrict this to the payer to avoid inserting time_to_first_payment metrics for every client
+	if me.IsPayer() {
+		mean := runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()
+		if runEnv.BooleanParam("isNightly") {
+			runEnv.R().RecordPoint(fmt.Sprintf("nightly_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
+		}
+		if runEnv.BooleanParam("isCI") {
+			runEnv.R().RecordPoint(fmt.Sprintf("ci_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
+		}
 	}
-	if runEnv.BooleanParam("isCI") {
-		runEnv.R().RecordPoint(fmt.Sprintf("ci_mean_time_to_first_payment,me=%s", me.Address), float64(mean))
-	}
-
 	client.MustSignalAndWait(ctx, "done", runEnv.TestInstanceCount)
 
 	return nil


### PR DESCRIPTION
It looks like the call to `runEnv.R().Timer(fmt.Sprintf("time_to_first_payment,me=%s", me.Address)).Mean()` will insert a `time_to_first_payment` metric if it does not exist.

This means that Hubs/Payees will show up on the TTFP with a 0 value at the end, which messes with our mean TTFP.
 ![image](https://user-images.githubusercontent.com/1620336/197039751-f730cd36-2029-402e-81a0-f860c3dfb11b.png) 

This PR restricts the ci/nightly metrics to just the payer. They're the only ones who have `time_to_first_payment` so it makes sense that only they calculate and add the nightly/ci metric.