### PR TITLE
Sync dashboards with grafana server

### DIFF
--- a/dashboards/engine-stats.json
+++ b/dashboards/engine-stats.json
@@ -1,47 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB",
-      "label": "InfluxDB",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.1.6"
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -67,135 +24,15 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
+        "uid": "n3gdqUn4k"
       },
-      "gridPos": {
-        "h": 10,
-        "w": 11,
-        "x": 0,
-        "y": 0
-      },
-      "id": 4,
-      "options": {
-        "content": "<table style=\"width:100%\">\n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n    <tr>\n    <td>Nitro Version</td>\n    <td>${nitroVersion}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
-        "mode": "html"
-      },
-      "pluginVersion": "9.1.6",
-      "title": "Run details",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 100000000
-              },
-              {
-                "color": "red",
-                "value": 1000000000
-              }
-            ]
-          },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 11,
-        "x": 11,
-        "y": 0
-      },
-      "id": 16,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.1.6",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            }
-          ],
-          "measurement": "results.go-nitro-testground-virtual-payment.time_to_first_payment.timer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "run",
-              "operator": "=~",
-              "value": "/^$runId$/"
-            }
-          ]
-        }
-      ],
-      "title": "Mean TTFP",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
-      },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -215,7 +52,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -250,17 +87,335 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 11,
+        "h": 8,
+        "w": 24,
         "x": 0,
-        "y": 10
+        "y": 0
       },
-      "id": 12,
+      "id": 2,
       "options": {
         "legend": {
           "calcs": [
+            "lastNotNull",
             "mean"
           ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "executeSideEffects",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "results.go-nitro-testground-virtual-payment.executeSideEffects.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        },
+        {
+          "alias": "handleMessage",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": true,
+          "measurement": "results.go-nitro-testground-virtual-payment.handleMessage.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        },
+        {
+          "alias": "handleObjectiveRequest",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": true,
+          "measurement": "results.go-nitro-testground-virtual-payment.handleObjectiveRequest.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        },
+        {
+          "alias": "attemptProgress",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": true,
+          "measurement": "results.go-nitro-testground-virtual-payment.attemptProgress.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        },
+        {
+          "alias": "send messages",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "results.go-nitro-testground-virtual-payment.sendMessages.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"mean\") FROM \"results.go-nitro-testground-virtual-payment.sendMessages.timer\" WHERE (\"run\" =~ /^$runId$/) AND $timeFilter GROUP BY time(1s) fill(linear)",
+          "rawQuery": false,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        }
+      ],
+      "title": "Average Function Call durations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "n3gdqUn4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -275,34 +430,19 @@
           "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
             {
               "params": [
                 "wallet"
               ],
               "type": "tag"
-            },
-            {
-              "params": [
-                "linear"
-              ],
-              "type": "fill"
             }
           ],
-          "hide": false,
-          "measurement": "results.go-nitro-testground-virtual-payment.objective_complete_time.timer",
+          "measurement": "results.go-nitro-testground-virtual-payment.attemptProgress.timer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"mean\") FROM \"results.go-nitro-testground-virtual-payment.objective_complete_time.timer\" WHERE (\"run\" =~ /^$runId$/ AND \"type\" = 'VirtualFund' AND $timeFilter GROUP BY time($__interval), \"wallet\" fill(none)",
-          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -312,10 +452,6 @@
                   "mean"
                 ],
                 "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
               }
             ]
           ],
@@ -324,25 +460,18 @@
               "key": "run",
               "operator": "=~",
               "value": "/^$runId$/"
-            },
-            {
-              "condition": "AND",
-              "key": "type",
-              "operator": "=",
-              "value": "VirtualFund"
             }
           ]
         }
       ],
-      "title": "Time to open virtual channel",
+      "title": "Attempt Progress",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
+        "uid": "n3gdqUn4k"
       },
-      "description": "This displays the average time to first payment for each client",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -362,7 +491,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -394,45 +523,18 @@
           },
           "unit": "ns"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Client 0x7f24f7d5fd84A2Af21F1C932d1a73419B1Ab82E8"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 11,
-        "x": 11,
-        "y": 10
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
       },
-      "id": 5,
+      "id": 4,
       "options": {
         "legend": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -444,32 +546,32 @@
       },
       "targets": [
         {
-          "alias": "Client $tag_me",
+          "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
               "params": [
-                "1s"
+                "$interval"
               ],
               "type": "time"
             },
             {
               "params": [
-                "me"
+                "wallet"
               ],
               "type": "tag"
             },
             {
               "params": [
-                "linear"
+                "none"
               ],
               "type": "fill"
             }
           ],
-          "measurement": "results.go-nitro-testground-virtual-payment.time_to_first_payment.timer",
+          "measurement": "results.go-nitro-testground-virtual-payment.executeSideEffects.timer",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -497,13 +599,132 @@
           ]
         }
       ],
-      "title": "Average time to first payment per client",
+      "title": "Execute Side Effects",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
+        "uid": "n3gdqUn4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_wallet",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "wallet"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "results.go-nitro-testground-virtual-payment.handleMessage.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        }
+      ],
+      "title": "Handle Message",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "n3gdqUn4k"
       },
       "fieldConfig": {
         "defaults": {
@@ -560,11 +781,11 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 11,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 17
       },
-      "id": 14,
+      "id": 3,
       "options": {
         "legend": {
           "calcs": [],
@@ -582,7 +803,7 @@
           "alias": "Message queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
@@ -619,7 +840,7 @@
           "alias": "Proposal queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
@@ -659,7 +880,7 @@
           "alias": "objective request queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
@@ -699,7 +920,7 @@
           "alias": "payment request queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
@@ -739,7 +960,7 @@
           "alias": "chain queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
+            "uid": "n3gdqUn4k"
           },
           "groupBy": [
             {
@@ -778,6 +999,141 @@
       ],
       "title": "Queue Sizes",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "n3gdqUn4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_wallet",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "n3gdqUn4k"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "wallet"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "results.go-nitro-testground-virtual-payment.handleObjectiveRequest.timer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "run",
+              "operator": "=~",
+              "value": "/^$runId$/"
+            }
+          ]
+        }
+      ],
+      "title": "Handle Objective Request",
+      "type": "timeseries"
     }
   ],
   "refresh": false,
@@ -787,209 +1143,22 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "ccpk2b8nr2gmvitl7c80",
+          "value": "ccpk2b8nr2gmvitl7c80"
+        },
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
+          "uid": "n3gdqUn4k"
         },
-        "definition": "select  run,count FROM \"results.go-nitro-testground-virtual-payment.time_to_first_payment.timer\" where $timeFilter",
+        "definition": " select run,mean from \"results.go-nitro-testground-virtual-payment.handleMessage.timer\" WHERE $timeFilter ",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "runId",
         "options": [],
-        "query": "select  run,count FROM \"results.go-nitro-testground-virtual-payment.time_to_first_payment.timer\" where $timeFilter",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT concurrentJobs, value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run = '$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "jobCount",
-        "options": [],
-        "query": "SELECT concurrentJobs, value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run = '$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"duration\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "testDuration",
-        "options": [],
-        "query": "SELECT \"duration\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"hubs\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "hubs",
-        "options": [],
-        "query": "SELECT \"hubs\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"payees\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "payees",
-        "options": [],
-        "query": "SELECT \"payees\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"jitter\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "jitter",
-        "options": [],
-        "query": "SELECT \"jitter\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"latency\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "latency",
-        "options": [],
-        "query": "SELECT \"latency\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "allValue": "",
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": " \"SELECT \\\"me\\\",count FROM \\\"results.go-nitro-testground-virtual-payment.time_to_first_payment.timer\\\" where run='$runId'\"",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "clientAdds",
-        "options": [],
-        "query": " \"SELECT \\\"me\\\",count FROM \\\"results.go-nitro-testground-virtual-payment.time_to_first_payment.timer\\\" where run='$runId'\"",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"payers\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "payers",
-        "options": [],
-        "query": "SELECT \"payers\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"payeePayers\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "payeepayers",
-        "options": [],
-        "query": "SELECT \"payeePayers\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "SELECT \"nitroVersion\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "nitroVersion",
-        "options": [],
-        "query": "SELECT \"nitroVersion\",value FROM \"results.go-nitro-testground-virtual-payment.run_info.point\" where run='$runId'",
+        "query": " select run,mean from \"results.go-nitro-testground-virtual-payment.handleMessage.timer\" WHERE $timeFilter ",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -999,13 +1168,13 @@
     ]
   },
   "time": {
-    "from": "now-30m",
-    "to": "now"
+    "from": "2022-09-27T18:31:03.832Z",
+    "to": "2022-09-27T18:31:43.239Z"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Time to First Payment",
-  "uid": "5OBBeW37k",
+  "title": "Engine stats",
+  "uid": "rjfjnW4Vk",
   "version": 13,
   "weekStart": ""
 }

--- a/dashboards/message-stats.json
+++ b/dashboards/message-stats.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.1.4"
+      "version": "9.1.6"
     },
     {
       "type": "datasource",
@@ -81,7 +81,7 @@
         "content": "<table style=\"width:100%\"> \n<thead>\n  <tr>\n    <th></th>\n    <th></th>\n  </tr>\n</thead>\n<tbody>\n  <tr>\n    <td>Run Id</td>\n    <td>${runId}</td>\n  </tr>\n    <tr>\n    <td>Nitro version</td>\n    <td>${nitroVersion}</td>\n  </tr>\n  <tr>\n    <td>Client Concurrency</td>\n    <td>${jobCount}</td>\n  </tr>\n  <tr>\n    <td>Payment test duration</td>\n    <td>${testDuration}</td>\n  </tr>\n  <tr>\n    <td>Number of payees</td>\n    <td>${payees}</td>\n  </tr>\n    <tr>\n    <td>Number of payers</td>\n    <td>${payers}</td>\n  </tr>\n     <tr>\n    <td>Number of payee-payers</td>\n    <td>${payeepayers}</td>\n  </tr>\n    <tr>\n    <td>Number of hubs</td>\n    <td>${hubs}</td>\n  </tr>\n      <tr>\n    <td>Latency (ms)</td>\n    <td>${latency}</td>\n  </tr>\n      <tr>\n    <td>Jitter (ms)</td>\n    <td>${jitter}</td>\n  </tr>\n</tbody>\n</table>",
         "mode": "html"
       },
-      "pluginVersion": "9.1.4",
+      "pluginVersion": "9.1.6",
       "title": "Run details",
       "type": "text"
     },
@@ -618,8 +618,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -885,7 +884,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Fixes #146 

Grabs the latest dashboards from the testground runner and adds them the the repo. The dashboards have undergone a bunch of tweaks around Lisbon (including the addition of a new dashboard) so we should make sure those changes are stored in git.