### PR TITLE
Accept Adjudicator address for wallaby as a parameter.

### DIFF
--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -14,11 +14,11 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	Create2Deployer "github.com/statechannels/go-nitro/client/engine/chainservice/create2deployer"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // NewWallabyChainService creates a new chain service for the Wallaby testnet
-// It uses a hard-coded address for the nitro adjudicator
-func NewWallabyChainService(ctx context.Context, seq int64, logDestination io.Writer) chainservice.ChainService {
+func NewWallabyChainService(ctx context.Context, seq int64, naAddress types.Address, logDestination io.Writer) chainservice.ChainService {
 
 	client, err := ethclient.Dial("https://wallaby.node.glif.io/rpc/v0")
 	if err != nil {
@@ -33,7 +33,6 @@ func NewWallabyChainService(ctx context.Context, seq int64, logDestination io.Wr
 		log.Fatal(err)
 	}
 
-	naAddress := common.HexToAddress("0x31582BBC5e4304AD53336921482653B2FE5Ed17e")
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
 		log.Fatal(err)

--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -33,7 +33,7 @@ func NewWallabyChainService(ctx context.Context, seq int64, logDestination io.Wr
 		log.Fatal(err)
 	}
 
-	naAddress := common.HexToAddress("0xab5c7Ff206Ed23180DbF9c6F3b98Ec984D0b0aB8")
+	naAddress := common.HexToAddress("0x31582BBC5e4304AD53336921482653B2FE5Ed17e")
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
 		log.Fatal(err)

--- a/config/config.go
+++ b/config/config.go
@@ -4,20 +4,24 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/types"
 	"github.com/testground/sdk-go/runtime"
 )
 
 // RunConfig is the configuration for a test run.
 type RunConfig struct {
-	NumHubs               uint
-	NumPayees             uint
-	NumPayers             uint
-	NumPayeePayers        uint
-	NumIntermediaries     uint
-	ConcurrentPaymentJobs uint
-	NetworkJitter         time.Duration
-	NetworkLatency        time.Duration
-	PaymentTestDuration   time.Duration
+	NumHubs                   uint
+	NumPayees                 uint
+	NumPayers                 uint
+	NumPayeePayers            uint
+	NumIntermediaries         uint
+	ConcurrentPaymentJobs     uint
+	NetworkJitter             time.Duration
+	NetworkLatency            time.Duration
+	PaymentTestDuration       time.Duration
+	UseWallaby                bool
+	WallabyAdjudicatorAddress types.Address
 }
 
 // Validate validates the config values. It uses instanceCount to check that it has the correct amount of roles.
@@ -43,6 +47,8 @@ func GetRunConfig(runEnv *runtime.RunEnv) (RunConfig, error) {
 	config.NetworkLatency = time.Duration(runEnv.IntParam(string(networkLatencyParam))) * time.Millisecond
 	config.PaymentTestDuration = time.Duration(runEnv.IntParam(string(paymentTestDurationParam))) * time.Second
 	config.ConcurrentPaymentJobs = uint(runEnv.IntParam(string(concurrentPaymentJobsParam)))
+	config.UseWallaby = (runEnv.BooleanParam(string(useWallabyParam)))
+	config.WallabyAdjudicatorAddress = common.HexToAddress(runEnv.StringParam(string(wallabyAdjudicatorAddress)))
 	err := config.Validate(uint(runEnv.TestInstanceCount))
 
 	return config, err

--- a/config/parameters.go
+++ b/config/parameters.go
@@ -13,4 +13,6 @@ const (
 	networkLatencyParam        param = "networkLatency"
 	concurrentPaymentJobsParam param = "concurrentPaymentJobs"
 	paymentTestDurationParam   param = "paymentTestDuration"
+	useWallabyParam            param = "useWallaby"
+	wallabyAdjudicatorAddress  param = "wallabyAdjudicatorAddress"
 )

--- a/manifest.toml
+++ b/manifest.toml
@@ -42,3 +42,4 @@ numOfPayees = {type = "int", default = 1, desc = "The number of instances that s
 numOfPayers = {type = "int", default = 1, desc = "The number of instances that should play the role of the payer"}
 paymentTestDuration = {type = "int", default = 10, unit = "seconds"}
 useWallaby = {type = "bool", default = false, desc = "Whether to use the public wallaby FEVM test network"}
+wallabyAdjudicatorAddress = {type = "string", default = "0x31582BBC5e4304AD53336921482653B2FE5Ed17e", desc = "The adjudicator address to use when performing the test against the wallaby FEVM test network"}

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -90,9 +90,10 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	logDestination, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0666)
 
 	var cs chainservice.ChainService
+
 	// If the wallaby flag is set we use the public wallaby node
-	if useWallaby := runEnv.BooleanParam("useWallaby"); useWallaby {
-		cs = chain.NewWallabyChainService(ctx, seq, logDestination)
+	if runConfig.UseWallaby {
+		cs = chain.NewWallabyChainService(ctx, seq, runConfig.WallabyAdjudicatorAddress, logDestination)
 	} else {
 		// All instances wait until the NitroAdjudicator has been deployed (seq = 1 instance is responsible)
 		cs = chain.NewChainService(ctx, seq, logDestination)


### PR DESCRIPTION
Right now wallaby gets reset pretty often, which means redeploying the contract and updating the hardcoded address. I've tried deploying using a deterministic address but that fails against wallaby (I think hardhat tries to deploy a proxy using a legacy transaction, which wallaby doesn't support).

For now I've added a `wallabyAdjudicatorAddress` parameter so we don't have to update the code constantly. The default value is the address of the  contract I just deployed today, so you can still get away just using the `useWallaby` flag for now.

Here's a run using the new parameter: http://34.168.92.245:8042/logs?task_id=cebvvpgnr2gn92sj9ge0