### PR TITLE
Export Engine Stats dashboard properly

### DIFF
--- a/dashboards/engine-stats.json
+++ b/dashboards/engine-stats.json
@@ -1,4 +1,35 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.3.6"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,15 +55,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "n3gdqUn4k"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -111,10 +138,6 @@
       "targets": [
         {
           "alias": "executeSideEffects",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "n3gdqUn4k"
-          },
           "groupBy": [
             {
               "params": [
@@ -154,7 +177,7 @@
           "alias": "handleMessage",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -202,7 +225,7 @@
           "alias": "handleObjectiveRequest",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -250,7 +273,7 @@
           "alias": "attemptProgress",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -298,7 +321,7 @@
           "alias": "send messages",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -351,7 +374,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "n3gdqUn4k"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -430,7 +453,7 @@
           "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -470,7 +493,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "n3gdqUn4k"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -549,7 +572,7 @@
           "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -605,7 +628,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "n3gdqUn4k"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -684,7 +707,7 @@
           "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -724,7 +747,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "n3gdqUn4k"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -803,7 +826,7 @@
           "alias": "Message queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -840,7 +863,7 @@
           "alias": "Proposal queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -880,7 +903,7 @@
           "alias": "objective request queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -920,7 +943,7 @@
           "alias": "payment request queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -960,7 +983,7 @@
           "alias": "chain queue $tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -1003,7 +1026,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "n3gdqUn4k"
+        "uid": "${DS_INFLUXDB}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1082,7 +1105,7 @@
           "alias": "$tag_wallet",
           "datasource": {
             "type": "influxdb",
-            "uid": "n3gdqUn4k"
+            "uid": "${DS_INFLUXDB}"
           },
           "groupBy": [
             {
@@ -1143,14 +1166,10 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "ccpk2b8nr2gmvitl7c80",
-          "value": "ccpk2b8nr2gmvitl7c80"
-        },
+        "current": {},
         "datasource": {
           "type": "influxdb",
-          "uid": "n3gdqUn4k"
+          "uid": "${DS_INFLUXDB}"
         },
         "definition": " select run,mean from \"results.go-nitro-testground-virtual-payment.handleMessage.timer\" WHERE $timeFilter ",
         "hide": 0,
@@ -1168,13 +1187,13 @@
     ]
   },
   "time": {
-    "from": "2022-09-27T18:31:03.832Z",
-    "to": "2022-09-27T18:31:43.239Z"
+    "from": "now-3h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Engine stats",
   "uid": "rjfjnW4Vk",
-  "version": 13,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Previously the engine stats dashboard was not exported properly so it had fixed references to a datasource id.
<img width="675" alt="image" src="https://user-images.githubusercontent.com/1620336/215171970-49015426-4431-4f4c-9d6b-9e3025889fd5.png">


This means that importing the report after a grafana reset would not work as the datasource no longer existed.

This replaces the dashboard with a properly exported version.