### PR TITLE
fix isComplete check

### DIFF
--- a/utils/monitor.go
+++ b/utils/monitor.go
@@ -37,9 +37,9 @@ func NewCompletionMonitor(client *nitroclient.Client, logFunc func(msg string, a
 func (c *CompletionMonitor) done(ids []protocols.ObjectiveId) bool {
 
 	for _, id := range ids {
-		isComplete, _ := c.completed.Load(string(id))
+		isComplete, ok := c.completed.Load(string(id))
 
-		if !isComplete.(bool) {
+		if !ok || !isComplete.(bool) {
 			return false
 		}
 	}


### PR DESCRIPTION
It looks like this check can fail if `c.completed.Load(string(id))` does not have an entry for `id` with
```
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/testground/sdk-go/run.HandlePanics()
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/run/panic.go:23 +0x39
panic({0x1083d20, 0xc000270c30})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/statechannels/go-nitro-testground/utils.(*CompletionMonitor).done(0xc00004e080, {0xc000410a00?, 0x1, 0xc000410a00?})
	/plan/utils/monitor.go:42 +0xc5
github.com/statechannels/go-nitro-testground/utils.(*CompletionMonitor).WaitForObjectivesToComplete(0x100dc40?, {0xc000410a00, 0x1, 0x1})
	/plan/utils/monitor.go:69 +0x4d
github.com/statechannels/go-nitro-testground/utils.CreateLedgerChannels({{0xc0005d2180, 0xc0005d21e0, 0xc000222c00, 0xc00039e360, 0xc0005d00c0, 0xc0005d0120, 0xc0005d2240, {0x176f4b0, 0xc000097d10}, {0x1776688, ...}, ...}, ...}, ...)
	/plan/utils/testing.go:208 +0xf6
github.com/statechannels/go-nitro-testground/tests.CreateVirtualPaymentTest(0xc000558000, 0xc000506540)
	/plan/tests/virtual-payment.go:115 +0xc45
github.com/testground/sdk-go/run.invoke.func4()
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/run/invoker.go:173 +0x142
created by github.com/testground/sdk-go/run.invoke
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/run/invoker.go:162 +0x78c
goroutine 1 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/testground/sdk-go/runtime.(*RunEnv).RecordCrash(0xc000558000, {0x100ef80?, 0xc000410a10?})
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/runtime/runenv_events.go:246 +0x7b
github.com/testground/sdk-go/run.invoke(0xc000558000, {0x103da40?, 0x15d22f0})
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/run/invoker.go:190 +0x8e5
github.com/testground/sdk-go/run.InvokeMap(0x106c260?)
	/go/pkg/mod/github.com/testground/sdk-go@v0.3.0/run/invoker.go:77 +0x94
main.main()
	/plan/main.go:10 +0xc5
```
See http://34.168.92.245:8042/logs?task_id=cgae49gnr2gnau9tf1vg

This PR fixes this by checking the `ok` value  returned by `Load` before attempting to cast the value