### PR TITLE
Updates CI based on go-nitro ci changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,19 +12,20 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.0"
+          go-version: "1.20.0"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.48.0
+          version: v1.51.2
+          args: --timeout 3m0s --verbose --modules-download-mode readonly
 
       - name: Run staticcheck # see: staticcheck.io
-        uses: dominikh/staticcheck-action@v1.2.0
+        uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1.2"
+          version: "2023.1.2"
           install-go: false
-          min-go-version: 1.19
+          min-go-version: 1.20
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
This updates the versions we're using in CI to the same ones that we use in `go-nitro`. This should help resolve any linting timeouts.