### PR TITLE
Upgrade to latest p2p message service constructor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/multiformats/go-multiaddr v0.8.0
-	github.com/statechannels/go-nitro v0.0.0-20230329050337-feb4d5c696e9
+	github.com/statechannels/go-nitro v0.0.0-20230331014722-10685d90c27c
 	github.com/tidwall/buntdb v1.2.10
 )
 
@@ -142,7 +142,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.11.4
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/libp2p/go-libp2p v0.26.2
+	github.com/libp2p/go-libp2p v0.26.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -872,8 +872,8 @@ github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bd
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/statechannels/go-nitro v0.0.0-20230329050337-feb4d5c696e9 h1:8k6tgO1/jBAHQM6nItgxKCzCsudYLz41krscrxqBrEA=
-github.com/statechannels/go-nitro v0.0.0-20230329050337-feb4d5c696e9/go.mod h1:8QRNph0V5MHK74d1rijokIehJOGrnj0GGXY6GzamN+A=
+github.com/statechannels/go-nitro v0.0.0-20230331014722-10685d90c27c h1:H7+mhVBzV6KJF9uQsdRXPn40XHH8B3dpeNAEaYz82pA=
+github.com/statechannels/go-nitro v0.0.0-20230331014722-10685d90c27c/go.mod h1:8QRNph0V5MHK74d1rijokIehJOGrnj0GGXY6GzamN+A=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -65,7 +65,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	ipAddress := ip.String()
 
 	// Create the ms using the given key
-	ms := p2pms.NewMessageService(ipAddress, port, address, utils.GenerateMessageKey(pk))
+	ms := p2pms.NewMessageService(ipAddress, port, address, pk)
 	client.MustSignalAndWait(ctx, "msStarted", runEnv.TestInstanceCount)
 
 	mePeerInfo := peer.PeerInfo{PeerInfo: p2pms.PeerInfo{Address: address, IpAddress: ipAddress, Port: port, Id: ms.Id()}, Role: role, Seq: seq}

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/statechannels/go-nitro-testground/config"
 	"github.com/statechannels/go-nitro-testground/peer"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
@@ -241,23 +239,4 @@ func RecordRunInfo(me peer.MyInfo, config config.RunConfig, metrics *runtime.Met
 
 	metrics.RecordPoint("run_info,"+runDetails, 1)
 
-}
-
-// generateMessageKey generates a ECDSA private key deterministically using the given pk bytes.
-func GenerateMessageKey(pk []byte) p2pcrypto.PrivKey {
-
-	// We use he given
-	totalSize := 256
-	large := make([]byte, totalSize)
-	copy(large, pk)
-
-	messageKey, _, err := p2pcrypto.GenerateECDSAKeyPair(bytes.NewReader(large))
-	if err != nil {
-		panic(err)
-	}
-
-	if err != nil {
-		panic(err)
-	}
-	return messageKey
 }


### PR DESCRIPTION
This updates the testground test to work with https://github.com/statechannels/go-nitro/pull/1201

[Successful run.](http://34.168.92.245:8042/logs?task_id=cgj589gnr2gkuiekem90)