### PR TITLE
Update to run against foundry anvil

### DIFF
--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -46,7 +46,7 @@ func NewHyperspaceChainService(ctx context.Context, seq int64, naAddress types.A
 }
 
 func NewChainService(ctx context.Context, seq int64, logDestination io.Writer, syncClient sync.Client, instances int) chainservice.ChainService {
-	client, err := ethclient.Dial("ws://hardhat:8545/")
+	client, err := ethclient.Dial("ws://chain:8545/")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func NewChainService(ctx context.Context, seq int64, logDestination io.Writer, s
 
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
-	log.Fatal(err)
+		log.Fatal(err)
 	}
 
 	cs, err := chainservice.NewEthChainService(client, na, naAddress, common.Address{}, common.Address{}, txSubmitter, logDestination)

--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -66,7 +66,10 @@ func NewChainService(ctx context.Context, seq int64, logDestination io.Writer, s
 	var naAddress types.Address
 	// One testground instance attempts to deploy NitroAdjudicator
 	if seq == 1 {
-		naAddress, _ = chainutils.DeployAdjudicator(ctx, client, txSubmitter)
+		naAddress, err = chainutils.DeployAdjudicator(ctx, client, txSubmitter)
+		if err != nil {
+			log.Fatal(err)
+		}
 		utils.SendAdjudicatorAddress(context.Background(), syncClient, naAddress)
 	} else {
 		naAddress = utils.WaitForAdjudicatorAddress(context.Background(), syncClient, instances)
@@ -74,7 +77,7 @@ func NewChainService(ctx context.Context, seq int64, logDestination io.Writer, s
 
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
-		log.Fatal(err)
+	log.Fatal(err)
 	}
 
 	cs, err := chainservice.NewEthChainService(client, na, naAddress, common.Address{}, common.Address{}, txSubmitter, logDestination)

--- a/chain/chain-service.go
+++ b/chain/chain-service.go
@@ -2,19 +2,19 @@ package chain
 
 import (
 	"context"
-	"encoding/hex"
 	"io"
 	"log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/statechannels/go-nitro-testground/utils"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
-	Create2Deployer "github.com/statechannels/go-nitro/client/engine/chainservice/create2deployer"
+	chainutils "github.com/statechannels/go-nitro/client/engine/chainservice/utils"
 	"github.com/statechannels/go-nitro/types"
+	"github.com/testground/sdk-go/sync"
 )
 
 // NewHyperspaceChainService creates a new chain service for the Hyperspace testnet
@@ -45,7 +45,7 @@ func NewHyperspaceChainService(ctx context.Context, seq int64, naAddress types.A
 	return cs
 }
 
-func NewChainService(ctx context.Context, seq int64, logDestination io.Writer) chainservice.ChainService {
+func NewChainService(ctx context.Context, seq int64, logDestination io.Writer, syncClient sync.Client, instances int) chainservice.ChainService {
 	client, err := ethclient.Dial("ws://hardhat:8545/")
 	if err != nil {
 		log.Fatal(err)
@@ -63,35 +63,13 @@ func NewChainService(ctx context.Context, seq int64, logDestination io.Writer) c
 	}
 	txSubmitter.GasPrice = gasPrice
 
-	deployer, err := Create2Deployer.NewCreate2Deployer(common.HexToAddress("0x5fbdb2315678afecb367f032d93f642f64180aa3"), client)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	hexBytecode, err := hex.DecodeString(NitroAdjudicator.NitroAdjudicatorMetaData.Bin[2:])
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	naAddress, err := deployer.ComputeAddress(&bind.CallOpts{}, [32]byte{}, crypto.Keccak256Hash(hexBytecode))
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	var naAddress types.Address
 	// One testground instance attempts to deploy NitroAdjudicator
 	if seq == 1 {
-		bytecode, err := client.CodeAt(ctx, naAddress, nil) // nil is latest block
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Has NitroAdjudicator been deployed? If not, deploy it.
-		if len(bytecode) == 0 {
-			_, err = deployer.Deploy(txSubmitter, big.NewInt(0), [32]byte{}, hexBytecode)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
+		naAddress, _ = chainutils.DeployAdjudicator(ctx, client, txSubmitter)
+		utils.SendAdjudicatorAddress(context.Background(), syncClient, naAddress)
+	} else {
+		naAddress = utils.WaitForAdjudicatorAddress(context.Background(), syncClient, instances)
 	}
 
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/multiformats/go-multiaddr v0.9.0
-	github.com/statechannels/go-nitro v0.0.0-20230413225843-e75d30833fea
+	github.com/statechannels/go-nitro v0.0.0-20230428154815-2871ed516e35
 	github.com/tidwall/buntdb v1.2.10
 )
 

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bd
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/statechannels/go-nitro v0.0.0-20230413225843-e75d30833fea h1:GWh2WmWi5D/ivWJV00MngcKU7hPQNqV6WTCEAbagvys=
-github.com/statechannels/go-nitro v0.0.0-20230413225843-e75d30833fea/go.mod h1:bE5swkU3wLbCugZ6kfQSmn0fb6V5pDXx5NM85T72WHA=
+github.com/statechannels/go-nitro v0.0.0-20230428154815-2871ed516e35 h1:xRgT4kpQ0G3VF/6ddPk7Dd0IyPeAehlqDVKRA9Jm4PM=
+github.com/statechannels/go-nitro v0.0.0-20230428154815-2871ed516e35/go.mod h1:bE5swkU3wLbCugZ6kfQSmn0fb6V5pDXx5NM85T72WHA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -96,7 +96,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 		cs = chain.NewHyperspaceChainService(ctx, seq, runConfig.HyperspaceAdjudicatorAddress, logDestination)
 	} else {
 		// All instances wait until the NitroAdjudicator has been deployed (seq = 1 instance is responsible)
-		cs = chain.NewChainService(ctx, seq, logDestination)
+		cs = chain.NewChainService(ctx, seq, logDestination, client, runEnv.TestInstanceCount)
 	}
 
 	client.MustSignalAndWait(ctx, sync.State("contractSetup"), runEnv.TestInstanceCount)

--- a/tests/virtual-payment.go
+++ b/tests/virtual-payment.go
@@ -102,7 +102,7 @@ func CreateVirtualPaymentTest(runEnv *runtime.RunEnv, init *run.InitContext) err
 	client.MustSignalAndWait(ctx, sync.State("contractSetup"), runEnv.TestInstanceCount)
 
 	nClient := nitro.New(ms, cs, store, logDestination, &engine.PermissivePolicy{}, runEnv.R())
-
+	defer nClient.Close()
 	cm := utils.NewCompletionMonitor(&nClient, runEnv.RecordMessage)
 	defer cm.Close()
 

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -137,6 +137,20 @@ func SharePeerInfo(me peer.PeerInfo, ctx context.Context, client sync.Client, in
 	return peers
 }
 
+func SendAdjudicatorAddress(ctx context.Context, client sync.Client, adjudicatorAddress types.Address) {
+	naTopic := sync.NewTopic("na-address", types.Address{})
+	_ = client.MustPublish(ctx, naTopic, adjudicatorAddress)
+}
+
+func WaitForAdjudicatorAddress(ctx context.Context, client sync.Client, instances int) types.Address {
+	naTopic := sync.NewTopic("na-address", types.Address{})
+	naChan := make(chan types.Address)
+
+	client.MustSubscribe(ctx, naTopic, naChan)
+	return <-naChan
+
+}
+
 // SelectRandom selects a random element from a slice.
 func SelectRandom[U ~[]T, T any](collection U) T {
 	randomIndex := rand.Intn(len(collection))


### PR DESCRIPTION
This updates the testground test to run against `foundry anvil`. There are two main changes:
- The testground test no longer relies on a `Create2Deployer` being deployed by the hardhat docker image. Instead one testground instance deploys the adjudicator and shares the address to it's peers.
- Update the url to use the non-implementation specific `chain` from `hardhat`

A successful run can be seen [here](http://34.168.92.245:8042/logs?task_id=ch6rom0nr2ghv4g3k3eg)

## Running Foundry Anvil on the TG Runner
Currently the testground runner is running a foundry docker image to run `anvil`. 

It can be started by running  
```
sudo docker run -d --name chain  foundry "anvil --host 0.0.0.0 --chain-id 1337"
```
(By default anvil listens on `127.0.0.1` but docker expects `0.0.0.0` so we have to specify that)
